### PR TITLE
API: refactoring + new schemas

### DIFF
--- a/api/api.json
+++ b/api/api.json
@@ -2,7 +2,7 @@
     "openapi": "3.0.2",
     "info": {
         "title": "Employee's cabinet",
-        "version": "0.11.0",
+        "version": "0.12.0",
         "description": "",
         "contact": {
             "name": "Yandex Practicum Students Team"
@@ -1130,47 +1130,6 @@
                     "required": true
                 }
             ]
-        },
-        "/login": {
-            "post": {
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Auth"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "token": {
-                                            "description": "PASETO Bearer Token for further authentication",
-                                            "type": "string",
-                                            "example": "v4.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ9v3Jt8mx_TdM2ceTGoqwrh4yDFn0XsHvvV_D0DtwQxVrJEBMl0F2caAdgnpKlt4p7xBnx1HcO-SPo8FPp214HDw.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9"
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "description": "Successful authentication response: bearer token"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/UnauthorizedError"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "operationId": "login",
-                "description": "Authenticates a user and returns a paseto bearer token on success"
-            }
         },
         "/users/{user_id}/scans/{scan_id}": {
             "get": {
@@ -2652,6 +2611,67 @@
                 },
                 "operationId": "changePassword",
                 "description": "Accepts a login and sends the key to change the password to the user email. \nOr it accepts the key and a new password and changes it."
+            }
+        },
+        "/login": {
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Auth"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "access_token",
+                                        "token_type"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "access_token": {
+                                            "description": "The access token issued by the server",
+                                            "type": "string"
+                                        },
+                                        "token_type": {
+                                            "description": "The type of the token issued",
+                                            "type": "string"
+                                        },
+                                        "expires_in": {
+                                            "description": "The lifetime in seconds of the access token",
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "examples": {
+                                    "Example": {
+                                        "value": {
+                                            "access_token": "v4.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ9v3Jt8mx_TdM2ceTGoqwrh4yDFn0XsHvvV_D0DtwQxVrJEBMl0F2caAdgnpKlt4p7xBnx1HcO-SPo8FPp214HDw.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9",
+                                            "token_type": "bearer",
+                                            "expires_in": 3600
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": "Successful authentication response: access token"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "operationId": "login",
+                "description": "Authenticates a user and returns an access token on success"
             }
         }
     },

--- a/api/api.json
+++ b/api/api.json
@@ -360,32 +360,6 @@
         },
         "/users/{user_id}/passports/{passport_id}/visas/{visa_id}": {
             "get": {
-                "parameters": [
-                    {
-                        "name": "user_id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "name": "passport_id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "name": "visa_id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "path",
-                        "required": true
-                    }
-                ],
                 "responses": {
                     "200": {
                         "content": {
@@ -468,32 +442,6 @@
                     },
                     "required": true
                 },
-                "parameters": [
-                    {
-                        "name": "user_id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "name": "passport_id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "name": "visa_id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "path",
-                        "required": true
-                    }
-                ],
                 "responses": {
                     "200": {
                         "description": "Employee visa updated response (empty)"
@@ -830,24 +778,6 @@
         },
         "/users/{user_id}/passports/{passport_id}": {
             "get": {
-                "parameters": [
-                    {
-                        "name": "user_id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "name": "passport_id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "path",
-                        "required": true
-                    }
-                ],
                 "responses": {
                     "200": {
                         "content": {
@@ -963,24 +893,6 @@
                 "description": "Returns the employee's passport based on ID"
             },
             "delete": {
-                "parameters": [
-                    {
-                        "name": "user_id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "name": "passport_id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "path",
-                        "required": true
-                    }
-                ],
                 "responses": {
                     "200": {
                         "description": "Employee passport deleted response (empty)"
@@ -1018,24 +930,6 @@
                     },
                     "required": true
                 },
-                "parameters": [
-                    {
-                        "name": "user_id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "name": "passport_id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "path",
-                        "required": true
-                    }
-                ],
                 "responses": {
                     "200": {
                         "description": "Employee passport updated response (empty)"
@@ -1305,115 +1199,8 @@
                 }
             ]
         },
-        "/users/{user_id}/scans/{scan_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "allOf": [
-                                        {
-                                            "$ref": "#/components/schemas/Scan"
-                                        },
-                                        {
-                                            "required": [
-                                                "id",
-                                                "type",
-                                                "upload_at"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            }
-                        },
-                        "description": "Employee document scan response"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/UnauthorizedError"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": []
-                    }
-                ],
-                "operationId": "getScan",
-                "description": "Returns the employee's document scan based on ID"
-            },
-            "delete": {
-                "parameters": [
-                    {
-                        "name": "scan_id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "name": "user_id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Employee scan deleted response (empty)"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/UnauthorizedError"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": []
-                    }
-                ],
-                "operationId": "deleteScan",
-                "description": "Deletes the employee's document scan based on ID"
-            },
-            "parameters": [
-                {
-                    "name": "user_id",
-                    "schema": {
-                        "type": "integer"
-                    },
-                    "in": "path",
-                    "required": true
-                },
-                {
-                    "name": "scan_id",
-                    "schema": {
-                        "type": "integer"
-                    },
-                    "in": "path",
-                    "required": true
-                }
-            ]
-        },
         "/users/{user_id}/scans": {
             "get": {
-                "parameters": [
-                    {
-                        "name": "user_id",
-                        "description": "employee ID",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "path",
-                        "required": true
-                    }
-                ],
                 "responses": {
                     "200": {
                         "content": {
@@ -1505,17 +1292,6 @@
                     },
                     "required": true
                 },
-                "parameters": [
-                    {
-                        "name": "user_id",
-                        "description": "employee ID",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "path",
-                        "required": true
-                    }
-                ],
                 "responses": {
                     "201": {
                         "headers": {
@@ -1787,19 +1563,125 @@
                 "description": "Creates a new employe in the company"
             }
         },
-        "/users/{user_id}": {
+        "/login": {
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Auth"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "token": {
+                                            "description": "PASETO Bearer Token for further authentication",
+                                            "type": "string",
+                                            "example": "v4.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ9v3Jt8mx_TdM2ceTGoqwrh4yDFn0XsHvvV_D0DtwQxVrJEBMl0F2caAdgnpKlt4p7xBnx1HcO-SPo8FPp214HDw.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": "Successful authentication response: bearer token"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "operationId": "login",
+                "description": "Authenticates a user and returns a paseto bearer token on success"
+            }
+        },
+        "/login/change-password": {
             "get": {
                 "parameters": [
                     {
-                        "name": "user_id",
-                        "description": "employee ID",
-                        "schema": {
-                            "type": "integer"
+                        "examples": {
+                            "Key": {
+                                "value": "\"0LzQsNC80LAg0LzRi9C70LAg0YDQsNC80YM=\""
+                            }
                         },
-                        "in": "path",
+                        "name": "key",
+                        "description": "a special key sent to the employee’s email",
+                        "schema": {
+                            "format": "byte",
+                            "type": "string"
+                        },
+                        "in": "query",
                         "required": true
                     }
                 ],
+                "responses": {
+                    "200": {
+                        "description": "Check a change password key response (empty)"
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest"
+                    },
+                    "429": {
+                        "description": "Too many request response"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "operationId": "checkKey",
+                "description": "Checks a password change key that was sent to the user's email"
+            },
+            "post": {
+                "requestBody": {
+                    "description": "One of the request types: only login to get recovery key on email or key & a new password to change password",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "oneOf": [
+                                    {
+                                        "$ref": "#/components/schemas/NewPassword"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/Login"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Change password response (empty)"
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest"
+                    },
+                    "404": {
+                        "description": "Employee not found"
+                    },
+                    "429": {
+                        "description": "Too many request response"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "operationId": "changePassword",
+                "description": "Accepts a login and sends the key to change the password to the user's email. \nOr it accepts the key and a new password and changes it."
+            }
+        },
+        "/users/{user_id}": {
+            "get": {
                 "responses": {
                     "200": {
                         "content": {
@@ -2134,35 +2016,29 @@
                 }
             ]
         },
-        "/login": {
-            "post": {
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Auth"
-                            }
-                        }
-                    },
-                    "required": true
-                },
+        "/users/{user_id}/scans/{scan_id}": {
+            "get": {
                 "responses": {
                     "200": {
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "token": {
-                                            "description": "PASETO Bearer Token for further authentication",
-                                            "type": "string",
-                                            "example": "v4.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ9v3Jt8mx_TdM2ceTGoqwrh4yDFn0XsHvvV_D0DtwQxVrJEBMl0F2caAdgnpKlt4p7xBnx1HcO-SPo8FPp214HDw.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9"
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/Scan"
+                                        },
+                                        {
+                                            "required": [
+                                                "id",
+                                                "type",
+                                                "upload_at"
+                                            ]
                                         }
-                                    }
+                                    ]
                                 }
                             }
                         },
-                        "description": "Successful authentication response: bearer token"
+                        "description": "Employee document scan response"
                     },
                     "401": {
                         "$ref": "#/components/responses/UnauthorizedError"
@@ -2171,85 +2047,52 @@
                         "$ref": "#/components/responses/InternalServerError"
                     }
                 },
-                "operationId": "login",
-                "description": "Authenticates a user and returns a paseto bearer token on success"
-            }
-        },
-        "/login/change-password": {
-            "get": {
-                "parameters": [
+                "security": [
                     {
-                        "examples": {
-                            "Key": {
-                                "value": "\"0LzQsNC80LAg0LzRi9C70LAg0YDQsNC80YM=\""
-                            }
-                        },
-                        "name": "key",
-                        "description": "a special key sent to the employee’s email",
-                        "schema": {
-                            "format": "byte",
-                            "type": "string"
-                        },
-                        "in": "query",
-                        "required": true
+                        "bearerAuth": []
                     }
                 ],
+                "operationId": "getScan",
+                "description": "Returns the employee's document scan based on ID"
+            },
+            "delete": {
                 "responses": {
                     "200": {
-                        "description": "Check a change password key response (empty)"
+                        "description": "Employee scan deleted response (empty)"
                     },
-                    "400": {
-                        "$ref": "#/components/responses/BadRequest"
-                    },
-                    "429": {
-                        "description": "Too many request response"
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
                     },
                     "500": {
                         "$ref": "#/components/responses/InternalServerError"
                     }
                 },
-                "operationId": "checkKey",
-                "description": "Checks a password change key that was sent to the user's email"
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "deleteScan",
+                "description": "Deletes the employee's document scan based on ID"
             },
-            "post": {
-                "requestBody": {
-                    "description": "One of the request types: only login to get recovery key on email or key & a new password to change password",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "oneOf": [
-                                    {
-                                        "$ref": "#/components/schemas/NewPassword"
-                                    },
-                                    {
-                                        "$ref": "#/components/schemas/Login"
-                                    }
-                                ]
-                            }
-                        }
+            "parameters": [
+                {
+                    "name": "user_id",
+                    "schema": {
+                        "type": "integer"
                     },
+                    "in": "path",
                     "required": true
                 },
-                "responses": {
-                    "200": {
-                        "description": "Change password response (empty)"
+                {
+                    "name": "scan_id",
+                    "schema": {
+                        "type": "integer"
                     },
-                    "400": {
-                        "$ref": "#/components/responses/BadRequest"
-                    },
-                    "404": {
-                        "description": "Employee not found"
-                    },
-                    "429": {
-                        "description": "Too many request response"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "operationId": "changePassword",
-                "description": "Accepts a login and sends the key to change the password to the user's email. \nOr it accepts the key and a new password and changes it."
-            }
+                    "in": "path",
+                    "required": true
+                }
+            ]
         }
     },
     "components": {

--- a/api/api.json
+++ b/api/api.json
@@ -2,7 +2,7 @@
     "openapi": "3.0.2",
     "info": {
         "title": "Employee's cabinet",
-        "version": "0.12.0",
+        "version": "0.14.0",
         "description": "",
         "contact": {
             "name": "Yandex Practicum Students Team"
@@ -62,7 +62,9 @@
                 },
                 "security": [
                     {
-                        "bearerAuth": []
+                        "bearerAuth": [
+                            "user:update"
+                        ]
                     }
                 ],
                 "operationId": "uploadPhoto"
@@ -106,7 +108,9 @@
                 },
                 "security": [
                     {
-                        "bearerAuth": []
+                        "bearerAuth": [
+                            "user:read"
+                        ]
                     }
                 ],
                 "operationId": "listContracts",
@@ -168,7 +172,9 @@
                 },
                 "security": [
                     {
-                        "bearerAuth": []
+                        "bearerAuth": [
+                            "user:update"
+                        ]
                     }
                 ],
                 "operationId": "addContract",
@@ -223,7 +229,9 @@
                 },
                 "security": [
                     {
-                        "bearerAuth": []
+                        "bearerAuth": [
+                            "user:read"
+                        ]
                     }
                 ],
                 "operationId": "getContract",
@@ -243,7 +251,9 @@
                 },
                 "security": [
                     {
-                        "bearerAuth": []
+                        "bearerAuth": [
+                            "user:update"
+                        ]
                     }
                 ],
                 "operationId": "deleteContract",
@@ -283,7 +293,9 @@
                 },
                 "security": [
                     {
-                        "bearerAuth": []
+                        "bearerAuth": [
+                            "user:update"
+                        ]
                     }
                 ],
                 "operationId": "patchContract",
@@ -348,7 +360,9 @@
                 },
                 "security": [
                     {
-                        "bearerAuth": []
+                        "bearerAuth": [
+                            "user:read"
+                        ]
                     }
                 ],
                 "operationId": "getVisa",
@@ -368,7 +382,9 @@
                 },
                 "security": [
                     {
-                        "bearerAuth": []
+                        "bearerAuth": [
+                            "user:update"
+                        ]
                     }
                 ],
                 "operationId": "deleteVisa",
@@ -408,7 +424,9 @@
                 },
                 "security": [
                     {
-                        "bearerAuth": []
+                        "bearerAuth": [
+                            "user:update"
+                        ]
                     }
                 ],
                 "operationId": "patchVisa",
@@ -484,7 +502,9 @@
                 },
                 "security": [
                     {
-                        "bearerAuth": []
+                        "bearerAuth": [
+                            "user:read"
+                        ]
                     }
                 ],
                 "operationId": "listVisas",
@@ -549,7 +569,9 @@
                 },
                 "security": [
                     {
-                        "bearerAuth": []
+                        "bearerAuth": [
+                            "user:update"
+                        ]
                     }
                 ],
                 "operationId": "addVisa",
@@ -684,7 +706,9 @@
                 },
                 "security": [
                     {
-                        "bearerAuth": []
+                        "bearerAuth": [
+                            "user:read"
+                        ]
                     }
                 ],
                 "operationId": "getPassport",
@@ -704,7 +728,9 @@
                 },
                 "security": [
                     {
-                        "bearerAuth": []
+                        "bearerAuth": [
+                            "user:update"
+                        ]
                     }
                 ],
                 "operationId": "deletePassport",
@@ -744,7 +770,9 @@
                 },
                 "security": [
                     {
-                        "bearerAuth": []
+                        "bearerAuth": [
+                            "user:update"
+                        ]
                     }
                 ],
                 "operationId": "patchPassport",
@@ -805,7 +833,9 @@
                 },
                 "security": [
                     {
-                        "bearerAuth": []
+                        "bearerAuth": [
+                            "user:read"
+                        ]
                     }
                 ],
                 "operationId": "getVacation",
@@ -825,7 +855,9 @@
                 },
                 "security": [
                     {
-                        "bearerAuth": []
+                        "bearerAuth": [
+                            "user:update"
+                        ]
                     }
                 ],
                 "operationId": "deleteVacation",
@@ -865,7 +897,9 @@
                 },
                 "security": [
                     {
-                        "bearerAuth": []
+                        "bearerAuth": [
+                            "user:update"
+                        ]
                     }
                 ],
                 "operationId": "patchVacation",
@@ -926,7 +960,9 @@
                 },
                 "security": [
                     {
-                        "bearerAuth": []
+                        "bearerAuth": [
+                            "user:read"
+                        ]
                     }
                 ],
                 "operationId": "listVacations",
@@ -980,7 +1016,9 @@
                 },
                 "security": [
                     {
-                        "bearerAuth": []
+                        "bearerAuth": [
+                            "user:update"
+                        ]
                     }
                 ],
                 "operationId": "addVacation",
@@ -1054,7 +1092,9 @@
                 },
                 "security": [
                     {
-                        "bearerAuth": []
+                        "bearerAuth": [
+                            "user:read"
+                        ]
                     }
                 ],
                 "operationId": "listScans",
@@ -1114,7 +1154,9 @@
                 },
                 "security": [
                     {
-                        "bearerAuth": []
+                        "bearerAuth": [
+                            "user:update"
+                        ]
                     }
                 ],
                 "operationId": "uploadScan",
@@ -1164,7 +1206,9 @@
                 },
                 "security": [
                     {
-                        "bearerAuth": []
+                        "bearerAuth": [
+                            "user:read"
+                        ]
                     }
                 ],
                 "operationId": "getScan",
@@ -1184,7 +1228,9 @@
                 },
                 "security": [
                     {
-                        "bearerAuth": []
+                        "bearerAuth": [
+                            "user:update"
+                        ]
                     }
                 ],
                 "operationId": "deleteScan",
@@ -1263,7 +1309,9 @@
                 },
                 "security": [
                     {
-                        "bearerAuth": []
+                        "bearerAuth": [
+                            "user:read"
+                        ]
                     }
                 ],
                 "operationId": "listDepartments",
@@ -1331,7 +1379,9 @@
                 },
                 "security": [
                     {
-                        "bearerAuth": []
+                        "bearerAuth": [
+                            "user:read"
+                        ]
                     }
                 ],
                 "operationId": "listPassports",
@@ -1397,7 +1447,9 @@
                 },
                 "security": [
                     {
-                        "bearerAuth": []
+                        "bearerAuth": [
+                            "user:update"
+                        ]
                     }
                 ],
                 "operationId": "addPassport",
@@ -1441,7 +1493,9 @@
                 },
                 "security": [
                     {
-                        "bearerAuth": []
+                        "bearerAuth": [
+                            "user:read"
+                        ]
                     }
                 ],
                 "operationId": "listEducations",
@@ -1502,7 +1556,9 @@
                 },
                 "security": [
                     {
-                        "bearerAuth": []
+                        "bearerAuth": [
+                            "user:update"
+                        ]
                     }
                 ],
                 "operationId": "addEducation",
@@ -1556,7 +1612,9 @@
                 },
                 "security": [
                     {
-                        "bearerAuth": []
+                        "bearerAuth": [
+                            "user:read"
+                        ]
                     }
                 ],
                 "operationId": "getEducation",
@@ -1576,7 +1634,9 @@
                 },
                 "security": [
                     {
-                        "bearerAuth": []
+                        "bearerAuth": [
+                            "user:update"
+                        ]
                     }
                 ],
                 "operationId": "deleteEducation",
@@ -1616,7 +1676,9 @@
                 },
                 "security": [
                     {
-                        "bearerAuth": []
+                        "bearerAuth": [
+                            "user:update"
+                        ]
                     }
                 ],
                 "operationId": "patchEducation",
@@ -1679,7 +1741,9 @@
                 },
                 "security": [
                     {
-                        "bearerAuth": []
+                        "bearerAuth": [
+                            "user:read"
+                        ]
                     }
                 ],
                 "operationId": "listTrainings",
@@ -1741,7 +1805,9 @@
                 },
                 "security": [
                     {
-                        "bearerAuth": []
+                        "bearerAuth": [
+                            "user:update"
+                        ]
                     }
                 ],
                 "operationId": "addTraining",
@@ -1796,7 +1862,9 @@
                 },
                 "security": [
                     {
-                        "bearerAuth": []
+                        "bearerAuth": [
+                            "user:read"
+                        ]
                     }
                 ],
                 "operationId": "getTraining",
@@ -1816,7 +1884,9 @@
                 },
                 "security": [
                     {
-                        "bearerAuth": []
+                        "bearerAuth": [
+                            "user:update"
+                        ]
                     }
                 ],
                 "operationId": "deleteTraining",
@@ -1856,7 +1926,9 @@
                 },
                 "security": [
                     {
-                        "bearerAuth": []
+                        "bearerAuth": [
+                            "user:update"
+                        ]
                     }
                 ],
                 "operationId": "patchTraining",
@@ -2020,7 +2092,9 @@
                 },
                 "security": [
                     {
-                        "bearerAuth": []
+                        "bearerAuth": [
+                            "user:read"
+                        ]
                     }
                 ],
                 "operationId": "listUsers",
@@ -2107,11 +2181,150 @@
                 },
                 "security": [
                     {
-                        "bearerAuth": []
+                        "bearerAuth": [
+                            "user:create"
+                        ]
                     }
                 ],
                 "operationId": "addUser",
                 "description": "Creates a new employe in the company"
+            }
+        },
+        "/login/change-password": {
+            "get": {
+                "parameters": [
+                    {
+                        "examples": {
+                            "Key": {
+                                "value": "0LzQsNC80LAg0LzRi9C70LAg0YDQsNC80YM="
+                            }
+                        },
+                        "name": "key",
+                        "description": "a special key sent to the employee’s email",
+                        "schema": {
+                            "format": "byte",
+                            "type": "string"
+                        },
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Check a change password key response (empty)"
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest"
+                    },
+                    "429": {
+                        "description": "Too many request response"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "operationId": "checkKey",
+                "description": "Checks a password change key that was sent to the user email"
+            },
+            "post": {
+                "requestBody": {
+                    "description": "One of the request types: only login to get recovery key on email or key & a new password to change password",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "oneOf": [
+                                    {
+                                        "$ref": "#/components/schemas/ChangePasswordRequest"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/InitChangePasswordRequest"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Change password response (empty)"
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest"
+                    },
+                    "404": {
+                        "description": "Employee not found"
+                    },
+                    "429": {
+                        "description": "Too many request response"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "operationId": "changePassword",
+                "description": "Accepts a login and sends the key to change the password to the user email. \nOr it accepts the key and a new password and changes it."
+            }
+        },
+        "/login": {
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Auth"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "required": [
+                                        "access_token",
+                                        "token_type"
+                                    ],
+                                    "type": "object",
+                                    "properties": {
+                                        "access_token": {
+                                            "description": "The access token issued by the server",
+                                            "type": "string"
+                                        },
+                                        "token_type": {
+                                            "description": "The type of the token issued",
+                                            "type": "string"
+                                        },
+                                        "expires_in": {
+                                            "description": "The lifetime in seconds of the access token",
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "examples": {
+                                    "Example": {
+                                        "value": {
+                                            "access_token": "v4.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ9v3Jt8mx_TdM2ceTGoqwrh4yDFn0XsHvvV_D0DtwQxVrJEBMl0F2caAdgnpKlt4p7xBnx1HcO-SPo8FPp214HDw.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9",
+                                            "token_type": "bearer",
+                                            "expires_in": 3600
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": "Successful authentication response: access token"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "operationId": "login",
+                "description": "Authenticates a user and returns an access token on success"
             }
         },
         "/users/{user_id}": {
@@ -2239,7 +2452,8 @@
                                                                 "required": [
                                                                     "id",
                                                                     "date_from",
-                                                                    "issued_institution"
+                                                                    "issued_institution",
+                                                                    "has_scan"
                                                                 ]
                                                             }
                                                         ]
@@ -2258,7 +2472,8 @@
                                                                     "id",
                                                                     "date_from",
                                                                     "issued_institution",
-                                                                    "program"
+                                                                    "program",
+                                                                    "has_scan"
                                                                 ]
                                                             }
                                                         ]
@@ -2475,7 +2690,9 @@
                 },
                 "security": [
                     {
-                        "bearerAuth": []
+                        "bearerAuth": [
+                            "user:read"
+                        ]
                     }
                 ],
                 "operationId": "getUser",
@@ -2519,7 +2736,9 @@
                 },
                 "security": [
                     {
-                        "bearerAuth": []
+                        "bearerAuth": [
+                            "user:update"
+                        ]
                     }
                 ],
                 "operationId": "patchUser",
@@ -2536,143 +2755,6 @@
                     "required": true
                 }
             ]
-        },
-        "/login/change-password": {
-            "get": {
-                "parameters": [
-                    {
-                        "examples": {
-                            "Key": {
-                                "value": "0LzQsNC80LAg0LzRi9C70LAg0YDQsNC80YM="
-                            }
-                        },
-                        "name": "key",
-                        "description": "a special key sent to the employee’s email",
-                        "schema": {
-                            "format": "byte",
-                            "type": "string"
-                        },
-                        "in": "query",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Check a change password key response (empty)"
-                    },
-                    "400": {
-                        "$ref": "#/components/responses/BadRequest"
-                    },
-                    "429": {
-                        "description": "Too many request response"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "operationId": "checkKey",
-                "description": "Checks a password change key that was sent to the user email"
-            },
-            "post": {
-                "requestBody": {
-                    "description": "One of the request types: only login to get recovery key on email or key & a new password to change password",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "oneOf": [
-                                    {
-                                        "$ref": "#/components/schemas/NewPassword"
-                                    },
-                                    {
-                                        "$ref": "#/components/schemas/Login"
-                                    }
-                                ]
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Change password response (empty)"
-                    },
-                    "400": {
-                        "$ref": "#/components/responses/BadRequest"
-                    },
-                    "404": {
-                        "description": "Employee not found"
-                    },
-                    "429": {
-                        "description": "Too many request response"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "operationId": "changePassword",
-                "description": "Accepts a login and sends the key to change the password to the user email. \nOr it accepts the key and a new password and changes it."
-            }
-        },
-        "/login": {
-            "post": {
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/Auth"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "required": [
-                                        "access_token",
-                                        "token_type"
-                                    ],
-                                    "type": "object",
-                                    "properties": {
-                                        "access_token": {
-                                            "description": "The access token issued by the server",
-                                            "type": "string"
-                                        },
-                                        "token_type": {
-                                            "description": "The type of the token issued",
-                                            "type": "string"
-                                        },
-                                        "expires_in": {
-                                            "description": "The lifetime in seconds of the access token",
-                                            "type": "integer"
-                                        }
-                                    }
-                                },
-                                "examples": {
-                                    "Example": {
-                                        "value": {
-                                            "access_token": "v4.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ9v3Jt8mx_TdM2ceTGoqwrh4yDFn0XsHvvV_D0DtwQxVrJEBMl0F2caAdgnpKlt4p7xBnx1HcO-SPo8FPp214HDw.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9",
-                                            "token_type": "bearer",
-                                            "expires_in": 3600
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "description": "Successful authentication response: access token"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/UnauthorizedError"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "operationId": "login",
-                "description": "Authenticates a user and returns an access token on success"
-            }
         }
     },
     "components": {
@@ -2926,53 +3008,6 @@
                         "type": "string",
                         "example": "2019-08-24T14:15:22Z"
                     }
-                }
-            },
-            "Login": {
-                "description": "",
-                "required": [
-                    "login"
-                ],
-                "type": "object",
-                "properties": {
-                    "login": {
-                        "format": "email",
-                        "description": "employee login (email)",
-                        "maxLength": 50,
-                        "minLength": 5,
-                        "type": "string"
-                    }
-                },
-                "example": {
-                    "login": "vasyapp&gazneft.ru"
-                }
-            },
-            "NewPassword": {
-                "description": "",
-                "required": [
-                    "key",
-                    "password"
-                ],
-                "type": "object",
-                "properties": {
-                    "key": {
-                        "format": "byte",
-                        "description": "a special key sent to the employee’s email",
-                        "maxLength": 64,
-                        "minLength": 64,
-                        "type": "string"
-                    },
-                    "password": {
-                        "format": "password",
-                        "description": "a new employee password",
-                        "maxLength": 15,
-                        "minLength": 8,
-                        "type": "string"
-                    }
-                },
-                "example": {
-                    "key": "0LzQsNC80LAg0LzRi9C70LAg0YDQsNC80YM=",
-                    "password": "pa$$word"
                 }
             },
             "Auth": {
@@ -3408,195 +3443,6 @@
                 ],
                 "type": "string"
             },
-            "FullUser": {
-                "required": [],
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/ShortUser"
-                    },
-                    {
-                        "properties": {
-                            "grade": {
-                                "description": "",
-                                "maxLength": 1,
-                                "minLength": 1,
-                                "type": "string"
-                            },
-                            "working_model": {
-                                "$ref": "#/components/schemas/WorkingModel",
-                                "description": ""
-                            },
-                            "date_of_birth": {
-                                "format": "date",
-                                "description": "",
-                                "type": "string"
-                            },
-                            "gender": {
-                                "enum": [
-                                    "male",
-                                    "female"
-                                ],
-                                "type": "string"
-                            },
-                            "place_of_birth": {
-                                "description": "",
-                                "maxLength": 150,
-                                "minLength": 2,
-                                "type": "string"
-                            },
-                            "registration_address": {
-                                "description": "",
-                                "maxLength": 150,
-                                "minLength": 2,
-                                "type": "string"
-                            },
-                            "residential_address": {
-                                "description": "",
-                                "maxLength": 150,
-                                "minLength": 2,
-                                "type": "string"
-                            },
-                            "nationality": {
-                                "description": "",
-                                "maxLength": 150,
-                                "minLength": 2,
-                                "type": "string"
-                            },
-                            "foreign_languages": {
-                                "description": "",
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "finance": {
-                                "$ref": "#/components/schemas/UserFinance",
-                                "readOnly": true
-                            },
-                            "position_track": {
-                                "description": "",
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/PositionTrack"
-                                    },
-                                    {
-                                        "required": [
-                                            "date_from",
-                                            "position"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "military": {
-                                "description": "",
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Military"
-                                    },
-                                    {
-                                        "required": [
-                                            "speciality",
-                                            "rank",
-                                            "comissariat",
-                                            "category"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "taxpayer": {
-                                "description": "",
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Taxpayer"
-                                    },
-                                    {
-                                        "required": [
-                                            "number"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "insurance": {
-                                "description": "",
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Insurance"
-                                    },
-                                    {
-                                        "required": [
-                                            "number"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "work_permit": {
-                                "description": "",
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/WorkPermit"
-                                    },
-                                    {
-                                        "required": [
-                                            "number",
-                                            "valid_to"
-                                        ]
-                                    }
-                                ]
-                            },
-                            "personal_data_processing": {
-                                "$ref": "#/components/schemas/PersonalDataProcessing",
-                                "description": ""
-                            }
-                        }
-                    }
-                ],
-                "example": {
-                    "id": 1,
-                    "first_name": "Alexander",
-                    "last_name": "Pushkin",
-                    "middle_name": "Sergeyevich",
-                    "position": "Novelist",
-                    "department": "Collegium of Foreign Affairs",
-                    "email": "pushkin@dantes.net",
-                    "phone_numbers": [
-                        {
-                            "number": "799183712345",
-                            "type": "mobile"
-                        },
-                        {
-                            "number": "1837",
-                            "type": "office"
-                        }
-                    ],
-                    "grade": "1",
-                    "working_model": "remote",
-                    "date_of_birth": "2018-01-17",
-                    "gender": "male",
-                    "place_of_birth": "Москва",
-                    "registration_address": "Санкт-Петербург, наб. реки Мойки, 12",
-                    "residential_address": "Санкт-Петербург, наб. реки Мойки, 12",
-                    "nationality": "Царская Россия",
-                    "foreign_languages": [
-                        "english",
-                        "french"
-                    ],
-                    "military": {
-                        "rank": "Старший лейтенант",
-                        "speciality": "101182",
-                        "category": "А2",
-                        "comissariat": "Военный комиссариат Петроградского района г. Санкт-Петербурга",
-                        "has_scan": true
-                    },
-                    "taxpayer": {
-                        "number": "500100732259",
-                        "has_scan": true
-                    },
-                    "insurance": {
-                        "number": "08336732477",
-                        "has_scan": true
-                    }
-                }
-            },
             "UserFinance": {
                 "description": "",
                 "type": "object",
@@ -3679,6 +3525,266 @@
                     "id": 95,
                     "has_scan": true
                 }
+            },
+            "FullUser": {
+                "required": [],
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/ShortUser"
+                    },
+                    {
+                        "properties": {
+                            "grade": {
+                                "description": "",
+                                "maxLength": 1,
+                                "minLength": 1,
+                                "type": "string"
+                            },
+                            "working_model": {
+                                "$ref": "#/components/schemas/WorkingModel",
+                                "description": ""
+                            },
+                            "date_of_birth": {
+                                "format": "date",
+                                "description": "",
+                                "type": "string"
+                            },
+                            "gender": {
+                                "enum": [
+                                    "male",
+                                    "female"
+                                ],
+                                "type": "string"
+                            },
+                            "place_of_birth": {
+                                "description": "",
+                                "maxLength": 150,
+                                "minLength": 2,
+                                "type": "string"
+                            },
+                            "registration_address": {
+                                "description": "",
+                                "maxLength": 150,
+                                "minLength": 2,
+                                "type": "string"
+                            },
+                            "residential_address": {
+                                "description": "",
+                                "maxLength": 150,
+                                "minLength": 2,
+                                "type": "string"
+                            },
+                            "nationality": {
+                                "description": "",
+                                "maxLength": 150,
+                                "minLength": 2,
+                                "type": "string"
+                            },
+                            "foreign_languages": {
+                                "description": "",
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "finance": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/UserFinance"
+                                    },
+                                    {
+                                        "required": [
+                                            "salary",
+                                            "social_security_tax",
+                                            "income_tax"
+                                        ]
+                                    }
+                                ],
+                                "readOnly": true
+                            },
+                            "position_track": {
+                                "description": "",
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/PositionTrack"
+                                    },
+                                    {
+                                        "required": [
+                                            "date_from",
+                                            "position"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "military": {
+                                "description": "",
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/Military"
+                                    },
+                                    {
+                                        "required": [
+                                            "speciality",
+                                            "rank",
+                                            "comissariat",
+                                            "category",
+                                            "has_scan"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "taxpayer": {
+                                "description": "",
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/Taxpayer"
+                                    },
+                                    {
+                                        "required": [
+                                            "number",
+                                            "has_scan"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "insurance": {
+                                "description": "",
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/Insurance"
+                                    },
+                                    {
+                                        "required": [
+                                            "number",
+                                            "has_scan"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "work_permit": {
+                                "description": "",
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/WorkPermit"
+                                    },
+                                    {
+                                        "required": [
+                                            "number",
+                                            "valid_to",
+                                            "has_scan"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "personal_data_processing": {
+                                "description": "",
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/PersonalDataProcessing"
+                                    },
+                                    {
+                                        "required": [
+                                            "has_scan"
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                ],
+                "example": {
+                    "id": 1,
+                    "first_name": "Alexander",
+                    "last_name": "Pushkin",
+                    "middle_name": "Sergeyevich",
+                    "position": "Novelist",
+                    "department": "Collegium of Foreign Affairs",
+                    "email": "pushkin@dantes.net",
+                    "phone_numbers": [
+                        {
+                            "number": "799183712345",
+                            "type": "mobile"
+                        },
+                        {
+                            "number": "1837",
+                            "type": "office"
+                        }
+                    ],
+                    "grade": "1",
+                    "working_model": "remote",
+                    "date_of_birth": "2018-01-17",
+                    "gender": "male",
+                    "place_of_birth": "Москва",
+                    "registration_address": "Санкт-Петербург, наб. реки Мойки, 12",
+                    "residential_address": "Санкт-Петербург, наб. реки Мойки, 12",
+                    "nationality": "Царская Россия",
+                    "foreign_languages": [
+                        "english",
+                        "french"
+                    ],
+                    "military": {
+                        "rank": "Старший лейтенант",
+                        "speciality": "101182",
+                        "category": "А2",
+                        "comissariat": "Военный комиссариат Петроградского района г. Санкт-Петербурга",
+                        "has_scan": true
+                    },
+                    "taxpayer": {
+                        "number": "500100732259",
+                        "has_scan": true
+                    },
+                    "insurance": {
+                        "number": "08336732477",
+                        "has_scan": true
+                    }
+                }
+            },
+            "InitChangePasswordRequest": {
+                "description": "",
+                "required": [
+                    "login"
+                ],
+                "type": "object",
+                "properties": {
+                    "login": {
+                        "format": "email",
+                        "description": "employee login (email)",
+                        "maxLength": 50,
+                        "minLength": 5,
+                        "type": "string"
+                    }
+                },
+                "example": {
+                    "login": "vasyapp&gazneft.ru"
+                }
+            },
+            "ChangePasswordRequest": {
+                "description": "",
+                "required": [
+                    "key",
+                    "password"
+                ],
+                "type": "object",
+                "properties": {
+                    "key": {
+                        "format": "byte",
+                        "description": "a special key sent to the employee’s email",
+                        "maxLength": 64,
+                        "minLength": 64,
+                        "type": "string"
+                    },
+                    "password": {
+                        "format": "password",
+                        "description": "a new employee password",
+                        "maxLength": 15,
+                        "minLength": 8,
+                        "type": "string"
+                    }
+                },
+                "example": {
+                    "key": "0LzQsNC80LAg0LzRi9C70LAg0YDQsNC80YM=",
+                    "password": "pa$$word"
+                }
             }
         },
         "responses": {
@@ -3716,7 +3822,7 @@
         "securitySchemes": {
             "bearerAuth": {
                 "scheme": "bearer",
-                "bearerFormat": "JWT",
+                "bearerFormat": "PASETO",
                 "type": "http",
                 "description": "auth: login+password, PASETO tokens"
             }

--- a/api/api.json
+++ b/api/api.json
@@ -2,7 +2,7 @@
     "openapi": "3.0.2",
     "info": {
         "title": "Employee's cabinet",
-        "version": "0.5.1",
+        "version": "0.6.0",
         "description": "",
         "contact": {
             "name": "Yandex Practicum Students Team"
@@ -64,6 +64,1247 @@
                 "description": "Returns a list of company departments with the number of employees"
             }
         },
+        "/users/{user_id}/photo": {
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "image/*": {
+                            "schema": {
+                                "format": "binary",
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "parameters": [
+                    {
+                        "name": "user_id",
+                        "description": "employee ID",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "headers": {
+                            "Location": {
+                                "schema": {
+                                    "format": "uri",
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Photo uploaded response, \nLocation header returns photo URL"
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "uploadPhoto"
+            }
+        },
+        "/users/{user_id}/contracts": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "allOf": [
+                                            {
+                                                "$ref": "#/components/schemas/Contract"
+                                            },
+                                            {
+                                                "required": [
+                                                    "id",
+                                                    "has_scan",
+                                                    "date_from",
+                                                    "type",
+                                                    "number"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                        "description": "Employee contracts list response"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "listContracts",
+                "description": "Returns list of employee's contracts"
+            },
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/Contract"
+                                    },
+                                    {
+                                        "required": [
+                                            "date_from",
+                                            "type",
+                                            "number"
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "headers": {
+                            "Location": {
+                                "schema": {
+                                    "format": "uri",
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Employee contract added response,\nLocation header returns a new employee contract URL"
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "409": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "description": "Add contract conflict response: the contract already exists"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "addContract",
+                "description": "Creates a new employee's contract"
+            },
+            "parameters": [
+                {
+                    "name": "user_id",
+                    "schema": {
+                        "type": "integer"
+                    },
+                    "in": "path",
+                    "required": true
+                }
+            ]
+        },
+        "/users/{user_id}/contracts/{contract_id}": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/Contract"
+                                        },
+                                        {
+                                            "required": [
+                                                "id",
+                                                "has_scan",
+                                                "date_from",
+                                                "type",
+                                                "number"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        "description": "Employee contract response"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "404": {
+                        "description": "Employee/contract not found response"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "getContract",
+                "description": "Returns the employee's contract based on ID"
+            },
+            "delete": {
+                "responses": {
+                    "200": {
+                        "description": "Employee contract deleted response (empty)"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "deleteContract",
+                "description": "Deletes the employee's contract based on ID"
+            },
+            "patch": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/Contract"
+                                    },
+                                    {
+                                        "minProperties": 1
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Employee contract updated response (empty)"
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "patchContract",
+                "description": "Changes selected fields in the employee's contract structure based on ID"
+            },
+            "parameters": [
+                {
+                    "name": "user_id",
+                    "schema": {
+                        "type": "integer"
+                    },
+                    "in": "path",
+                    "required": true
+                },
+                {
+                    "name": "contract_id",
+                    "schema": {
+                        "type": "integer"
+                    },
+                    "in": "path",
+                    "required": true
+                }
+            ]
+        },
+        "/users/{user_id}/passports/{passport_id}/visas/{visa_id}": {
+            "get": {
+                "parameters": [
+                    {
+                        "name": "user_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "name": "passport_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "name": "visa_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/Visa"
+                                        },
+                                        {
+                                            "required": [
+                                                "id",
+                                                "has_scan",
+                                                "number",
+                                                "issued_state",
+                                                "valid_to",
+                                                "valid_from",
+                                                "number_entries"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        "description": "Employee visa response"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "404": {
+                        "description": "Employee/passport/visa not found response"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "getVisa",
+                "description": "Returns the employee's visa based on ID"
+            },
+            "delete": {
+                "responses": {
+                    "200": {
+                        "description": "Employee visa deleted response (empty)"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "deleteVisa",
+                "description": "Deletes the employee's visa based on ID"
+            },
+            "patch": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/Visa"
+                                    },
+                                    {
+                                        "minProperties": 1
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "parameters": [
+                    {
+                        "name": "user_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "name": "passport_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "name": "visa_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Employee visa updated response (empty)"
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "patchVisa",
+                "description": "Changes selected fields in the employee's visa structure based on ID"
+            },
+            "parameters": [
+                {
+                    "name": "user_id",
+                    "schema": {
+                        "type": "integer"
+                    },
+                    "in": "path",
+                    "required": true
+                },
+                {
+                    "name": "passport_id",
+                    "schema": {
+                        "type": "integer"
+                    },
+                    "in": "path",
+                    "required": true
+                },
+                {
+                    "name": "visa_id",
+                    "schema": {
+                        "type": "integer"
+                    },
+                    "in": "path",
+                    "required": true
+                }
+            ]
+        },
+        "/users/{user_id}/passports/{passport_id}/visas": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "allOf": [
+                                            {
+                                                "$ref": "#/components/schemas/Visa"
+                                            },
+                                            {
+                                                "required": [
+                                                    "id",
+                                                    "has_scan",
+                                                    "number",
+                                                    "issued_state",
+                                                    "valid_to",
+                                                    "valid_from",
+                                                    "number_entries"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                        "description": "List employee visas for this passport"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "404": {
+                        "description": "Employee/passport not found response"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "listVisas",
+                "description": "Returns list of employee's visas"
+            },
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/Visa"
+                                    },
+                                    {
+                                        "required": [
+                                            "number",
+                                            "issued_state",
+                                            "valid_to",
+                                            "valid_from",
+                                            "number_entries"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "examples": {
+                                "New visa example": {
+                                    "value": {
+                                        "number": "33592222",
+                                        "issued_state": "Spain",
+                                        "valid_to": "2017-09-22",
+                                        "valid_from": "2017-10-08",
+                                        "number_entries": "1"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "headers": {
+                            "Location": {
+                                "schema": {
+                                    "format": "uri",
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Employee visa added response,\nLocation header returns a new employee visa URL"
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "addVisa",
+                "description": "Creates a new employee's visa"
+            },
+            "parameters": [
+                {
+                    "name": "user_id",
+                    "schema": {
+                        "type": "integer"
+                    },
+                    "in": "path",
+                    "required": true
+                },
+                {
+                    "name": "passport_id",
+                    "schema": {
+                        "type": "integer"
+                    },
+                    "in": "path",
+                    "required": true
+                }
+            ]
+        },
+        "/users/{user_id}/passports": {
+            "get": {
+                "parameters": [
+                    {
+                        "name": "user_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "allOf": [
+                                            {
+                                                "$ref": "#/components/schemas/Passport"
+                                            },
+                                            {
+                                                "required": [
+                                                    "id",
+                                                    "number",
+                                                    "issued_date",
+                                                    "issued_by",
+                                                    "type",
+                                                    "has_scan"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "visas": {
+                                                        "description": "",
+                                                        "type": "array",
+                                                        "items": {
+                                                            "allOf": [
+                                                                {
+                                                                    "$ref": "#/components/schemas/Visa"
+                                                                },
+                                                                {
+                                                                    "required": [
+                                                                        "id",
+                                                                        "has_scan",
+                                                                        "number",
+                                                                        "issued_state",
+                                                                        "valid_to",
+                                                                        "valid_from",
+                                                                        "number_entries"
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                        "description": "List employee passports"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "404": {
+                        "description": "Employee not found response"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "listPassports",
+                "description": "Returns list of employee's passport"
+            },
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/Passport"
+                                    },
+                                    {
+                                        "required": [
+                                            "number",
+                                            "issued_date",
+                                            "issued_by",
+                                            "type"
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "parameters": [
+                    {
+                        "name": "user_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "headers": {
+                            "Location": {
+                                "schema": {
+                                    "format": "uri",
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Passport added response, \nLocation header returns a new employee passport URL"
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "409": {
+                        "description": "Add passport conflict response: the passport already exists"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "addPassport",
+                "description": "Creates a new employee's passport"
+            }
+        },
+        "/users/{user_id}/passports/{passport_id}": {
+            "get": {
+                "parameters": [
+                    {
+                        "name": "user_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "name": "passport_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/Passport"
+                                        },
+                                        {
+                                            "required": [
+                                                "id",
+                                                "number",
+                                                "issued_date",
+                                                "issued_by",
+                                                "type",
+                                                "has_scan"
+                                            ]
+                                        },
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "visas": {
+                                                    "description": "",
+                                                    "type": "array",
+                                                    "items": {
+                                                        "allOf": [
+                                                            {
+                                                                "$ref": "#/components/schemas/Visa"
+                                                            },
+                                                            {
+                                                                "required": [
+                                                                    "id",
+                                                                    "has_scan",
+                                                                    "number",
+                                                                    "issued_state",
+                                                                    "valid_to",
+                                                                    "valid_from",
+                                                                    "number_entries"
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                "examples": {
+                                    "Foreigners passport example": {
+                                        "value": {
+                                            "id": 75,
+                                            "visas": [
+                                                {
+                                                    "id": 3,
+                                                    "number": "33592222",
+                                                    "issued_state": "Russia",
+                                                    "valid_to": "2017-09-22",
+                                                    "valid_from": "2018-09-22",
+                                                    "number_entries": "mult",
+                                                    "has_scan": true
+                                                }
+                                            ],
+                                            "number": "33592222",
+                                            "issued_date": "2016-05-15",
+                                            "issued_by": "Washington D.C. U.S.A.",
+                                            "type": "foreigners",
+                                            "has_scan": false
+                                        }
+                                    },
+                                    "Internal passport example": {
+                                        "value": {
+                                            "id": 98,
+                                            "visas": [
+                                                {
+                                                    "id": 9,
+                                                    "number": "33592222",
+                                                    "issued_state": "Germany",
+                                                    "valid_to": "2017-09-22",
+                                                    "valid_from": "2017-10-08",
+                                                    "number_entries": "2",
+                                                    "has_scan": false
+                                                }
+                                            ],
+                                            "number": "4011364219",
+                                            "issued_date": "2016-05-15",
+                                            "issued_by": "ТП № 28 отдела УФМС России по СПб и ЛО",
+                                            "type": "internal",
+                                            "has_scan": false
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": "Employee passport response"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "404": {
+                        "description": "Employee/passport not found response"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "getPassport",
+                "description": "Returns the employee's passport based on ID"
+            },
+            "delete": {
+                "parameters": [
+                    {
+                        "name": "user_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "name": "passport_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Employee passport deleted response (empty)"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "deletePassport",
+                "description": "Deletes the employee's passport based on ID"
+            },
+            "patch": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/Passport"
+                                    },
+                                    {
+                                        "minProperties": 1
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "parameters": [
+                    {
+                        "name": "user_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "name": "passport_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Employee passport updated response (empty)"
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "patchPassport",
+                "description": "Changes selected fields in the employee's passport structure based on ID"
+            },
+            "parameters": [
+                {
+                    "name": "user_id",
+                    "schema": {
+                        "type": "integer"
+                    },
+                    "in": "path",
+                    "required": true
+                },
+                {
+                    "name": "passport_id",
+                    "schema": {
+                        "type": "integer"
+                    },
+                    "in": "path",
+                    "required": true
+                }
+            ]
+        },
+        "/users/{user_id}/vacations/{vacation_id}": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/Vacation"
+                                        },
+                                        {
+                                            "required": [
+                                                "id",
+                                                "date_from",
+                                                "date_to"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        "description": "Employee vacation response"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "404": {
+                        "description": "Employee/vacation not found response"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "getVacation",
+                "description": "Returns the employee's vacation based on ID"
+            },
+            "delete": {
+                "responses": {
+                    "200": {
+                        "description": "Vacation deleted response (empty)"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "deleteVacation",
+                "description": "Deletes the employee's vacation based on ID"
+            },
+            "patch": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/Vacation"
+                                    },
+                                    {
+                                        "minProperties": 1
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Vacation updated response"
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "patchVacation",
+                "description": "Changes selected fields in the employee's vacation structure based on ID"
+            },
+            "parameters": [
+                {
+                    "name": "user_id",
+                    "schema": {
+                        "type": "integer"
+                    },
+                    "in": "path",
+                    "required": true
+                },
+                {
+                    "name": "vacation_id",
+                    "schema": {
+                        "type": "integer"
+                    },
+                    "in": "path",
+                    "required": true
+                }
+            ]
+        },
+        "/users/{user_id}/vacations": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "allOf": [
+                                            {
+                                                "$ref": "#/components/schemas/Vacation"
+                                            },
+                                            {
+                                                "required": [
+                                                    "id",
+                                                    "date_from",
+                                                    "date_to"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                        "description": "Employee vacations list response"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "listVacations",
+                "description": "Returns list of employee's vacations"
+            },
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/Vacation"
+                                    },
+                                    {
+                                        "required": [
+                                            "date_from",
+                                            "date_to"
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "headers": {
+                            "Location": {
+                                "schema": {
+                                    "format": "uri",
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Employee vacation added response, \nLocation header returns vacation URL"
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "409": {
+                        "description": "Add vacation conflict response: the dates indicated conflict with the available ones"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "postVacation",
+                "description": "Creates a new employee's vacation"
+            },
+            "parameters": [
+                {
+                    "name": "user_id",
+                    "schema": {
+                        "type": "integer"
+                    },
+                    "in": "path",
+                    "required": true
+                }
+            ]
+        },
         "/users/{user_id}/scans/{scan_id}": {
             "get": {
                 "responses": {
@@ -71,7 +1312,18 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/GetScan"
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/Scan"
+                                        },
+                                        {
+                                            "required": [
+                                                "id",
+                                                "type",
+                                                "upload_at"
+                                            ]
+                                        }
+                                    ]
                                 }
                             }
                         },
@@ -149,14 +1401,105 @@
                 }
             ]
         },
-        "/users/{user_id}/photo": {
+        "/users/{user_id}/scans": {
+            "get": {
+                "parameters": [
+                    {
+                        "name": "user_id",
+                        "description": "employee ID",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "allOf": [
+                                            {
+                                                "$ref": "#/components/schemas/Scan"
+                                            },
+                                            {
+                                                "required": [
+                                                    "id",
+                                                    "type",
+                                                    "upload_at"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                "examples": {
+                                    "Scans list example": {
+                                        "value": [
+                                            {
+                                                "id": 7,
+                                                "upload_at": "2019-03-10T09:30Z",
+                                                "type": "passport",
+                                                "document_id": 7
+                                            },
+                                            {
+                                                "id": 81,
+                                                "upload_at": "2018-02-10T09:30Z",
+                                                "type": "baby_birth",
+                                                "description": "not verified by social services"
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                        "description": "Employee scans list response"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "404": {
+                        "description": "Employee not found response"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "listScans",
+                "description": "Returns list of employee's document scans"
+            },
             "post": {
                 "requestBody": {
                     "content": {
-                        "image/*": {
+                        "multipart/form-data": {
                             "schema": {
-                                "format": "binary",
-                                "type": "string"
+                                "required": [
+                                    "type",
+                                    "fileName"
+                                ],
+                                "type": "object",
+                                "properties": {
+                                    "type": {
+                                        "$ref": "#/components/schemas/ScanType"
+                                    },
+                                    "document_id": {
+                                        "type": "integer"
+                                    },
+                                    "description": {
+                                        "type": "string"
+                                    },
+                                    "fileName": {
+                                        "format": "binary",
+                                        "type": "string"
+                                    }
+                                }
                             }
                         }
                     },
@@ -178,12 +1521,12 @@
                         "headers": {
                             "Location": {
                                 "schema": {
-                                    "format": "url",
+                                    "format": "uri",
                                     "type": "string"
                                 }
                             }
                         },
-                        "description": "Photo uploaded response, \nLocation header returns photo URL"
+                        "description": "Scan uploaded response, \nLocation header returns scan URL"
                     },
                     "400": {
                         "$ref": "#/components/responses/BadRequest"
@@ -200,7 +1543,248 @@
                         "bearerAuth": []
                     }
                 ],
-                "operationId": "uploadPhoto"
+                "operationId": "uploadScan",
+                "description": "Creates a new employee's document scan"
+            },
+            "parameters": [
+                {
+                    "name": "user_id",
+                    "schema": {
+                        "type": "integer"
+                    },
+                    "in": "path",
+                    "required": true
+                }
+            ]
+        },
+        "/users": {
+            "get": {
+                "parameters": [
+                    {
+                        "examples": {
+                            "Limit example": {
+                                "value": "50"
+                            }
+                        },
+                        "name": "limit",
+                        "description": "maximum number of results to return",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "in": "query",
+                        "required": false
+                    },
+                    {
+                        "examples": {
+                            "Query": {
+                                "value": "\"Иванов\""
+                            }
+                        },
+                        "name": "query",
+                        "description": "query to find by",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "in": "query"
+                    },
+                    {
+                        "examples": {
+                            "Page example": {
+                                "value": "2"
+                            }
+                        },
+                        "name": "page",
+                        "description": "page number with results to return",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "in": "query"
+                    },
+                    {
+                        "examples": {
+                            "SortByExample": {
+                                "value": "\"alphabet\""
+                            }
+                        },
+                        "name": "sort_by",
+                        "description": "type of sort result by",
+                        "schema": {
+                            "enum": [
+                                "alphabet",
+                                "department"
+                            ],
+                            "type": "string"
+                        },
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "allOf": [
+                                            {
+                                                "$ref": "#/components/schemas/ShortUser"
+                                            },
+                                            {
+                                                "required": [
+                                                    "id",
+                                                    "first_name",
+                                                    "last_name"
+                                                ],
+                                                "type": "object"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "examples": {
+                                    "List employees example": {
+                                        "value": [
+                                            {
+                                                "first_name": "Alexander",
+                                                "last_name": "Pushkin",
+                                                "middle_name": "Sergeyevich",
+                                                "position": "Novelist",
+                                                "department": "Collegium of Foreign Affairs",
+                                                "email": "pushkin@dantes.net",
+                                                "phone_numbers": [
+                                                    {
+                                                        "number": "799183712345",
+                                                        "type": "mobile"
+                                                    },
+                                                    {
+                                                        "number": "1837",
+                                                        "type": "office"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "first_name": "Nikolai",
+                                                "last_name": "Gogol",
+                                                "middle_name": "Vasilievich",
+                                                "position": "Playwright",
+                                                "department": "Third Section of His Imperial Majesty's Own Chancellery",
+                                                "email": "gogol@fire.net",
+                                                "phone_numbers": [
+                                                    {
+                                                        "number": "799185212345",
+                                                        "type": "mobile"
+                                                    },
+                                                    {
+                                                        "number": "1821",
+                                                        "type": "office"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                        "description": "Employees list response"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "listUsers",
+                "description": "Returns list of company employees sorted alphabetically (default) or by department"
+            },
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/FullUser"
+                                    },
+                                    {
+                                        "required": [
+                                            "first_name",
+                                            "last_name",
+                                            "date_of_birth"
+                                        ],
+                                        "type": "object"
+                                    }
+                                ]
+                            },
+                            "examples": {
+                                "Post employee example": {
+                                    "value": {
+                                        "first_name": "Alexander",
+                                        "last_name": "Pushkin",
+                                        "middle_name": "Sergeyevich",
+                                        "position": "Novelist",
+                                        "department": "Collegium of Foreign Affairs",
+                                        "email": "pushkin@dantes.net",
+                                        "phone_numbers": [
+                                            {
+                                                "number": "799183712345",
+                                                "type": "mobile"
+                                            },
+                                            {
+                                                "number": "1837",
+                                                "type": "office"
+                                            }
+                                        ],
+                                        "foreign_languages": [
+                                            "english",
+                                            "german"
+                                        ],
+                                        "military": {
+                                            "rank": "Старший лейтенант",
+                                            "speciality": "101182",
+                                            "category": "А2",
+                                            "comissariat": "Военный комиссариат Петроградского района г. Санкт-Петербурга"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "headers": {
+                            "Location": {
+                                "schema": {
+                                    "format": "uri",
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Employee created response, \nLocation header returns a new employee URL"
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "addUser",
+                "description": "Creates a new employe in the company"
             }
         },
         "/users/{user_id}": {
@@ -221,7 +1805,114 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/GetFullUser"
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/FullUser"
+                                        },
+                                        {
+                                            "required": [
+                                                "id",
+                                                "first_name",
+                                                "last_name",
+                                                "date_of_birth"
+                                            ]
+                                        },
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "id": {
+                                                    "description": "",
+                                                    "type": "integer"
+                                                },
+                                                "passports": {
+                                                    "description": "",
+                                                    "type": "array",
+                                                    "items": {
+                                                        "allOf": [
+                                                            {
+                                                                "$ref": "#/components/schemas/Passport"
+                                                            },
+                                                            {
+                                                                "required": [
+                                                                    "id",
+                                                                    "number",
+                                                                    "issued_date",
+                                                                    "issued_by",
+                                                                    "type",
+                                                                    "has_scan"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "visas": {
+                                                                        "description": "",
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "allOf": [
+                                                                                {
+                                                                                    "$ref": "#/components/schemas/Visa"
+                                                                                },
+                                                                                {
+                                                                                    "required": [
+                                                                                        "id",
+                                                                                        "has_scan",
+                                                                                        "number",
+                                                                                        "issued_state",
+                                                                                        "valid_to",
+                                                                                        "valid_from",
+                                                                                        "number_entries"
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                "contracts": {
+                                                    "description": "",
+                                                    "type": "array",
+                                                    "items": {
+                                                        "allOf": [
+                                                            {
+                                                                "$ref": "#/components/schemas/Contract"
+                                                            },
+                                                            {
+                                                                "required": [
+                                                                    "id",
+                                                                    "has_scan",
+                                                                    "date_from",
+                                                                    "type",
+                                                                    "number"
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                "vacations": {
+                                                    "description": "",
+                                                    "type": "array",
+                                                    "items": {
+                                                        "allOf": [
+                                                            {
+                                                                "$ref": "#/components/schemas/Vacation"
+                                                            },
+                                                            {
+                                                                "required": [
+                                                                    "id",
+                                                                    "date_from",
+                                                                    "date_to"
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ]
                                 },
                                 "examples": {
                                     "Employee example": {
@@ -384,7 +2075,15 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/PatchFullUser"
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/FullUser"
+                                    },
+                                    {
+                                        "minProperties": 1,
+                                        "type": "object"
+                                    }
+                                ]
                             },
                             "examples": {
                                 "Path example": {
@@ -435,141 +2134,6 @@
                 }
             ]
         },
-        "/users/{user_id}/scans": {
-            "get": {
-                "parameters": [
-                    {
-                        "name": "user_id",
-                        "description": "employee ID",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/GetScan"
-                                    }
-                                },
-                                "examples": {
-                                    "Scans list example": {
-                                        "value": [
-                                            {
-                                                "id": 7,
-                                                "upload_at": "2019-03-10T09:30Z",
-                                                "type": "passport",
-                                                "document_id": 7
-                                            },
-                                            {
-                                                "id": 81,
-                                                "upload_at": "2018-02-10T09:30Z",
-                                                "type": "baby_birth",
-                                                "description": "not verified by social services"
-                                            }
-                                        ]
-                                    }
-                                }
-                            }
-                        },
-                        "description": "Employee scans list response"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/UnauthorizedError"
-                    },
-                    "404": {
-                        "description": "Employee not found response"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": []
-                    }
-                ],
-                "operationId": "listScans",
-                "description": "Returns list of employee's document scans"
-            },
-            "post": {
-                "requestBody": {
-                    "content": {
-                        "multipart/form-data": {
-                            "schema": {
-                                "required": [
-                                    "type",
-                                    "fileName"
-                                ],
-                                "type": "object",
-                                "properties": {
-                                    "type": {
-                                        "$ref": "#/components/schemas/ScanType"
-                                    },
-                                    "document_id": {
-                                        "type": "integer"
-                                    },
-                                    "description": {
-                                        "type": "string"
-                                    },
-                                    "fileName": {
-                                        "format": "binary",
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "parameters": [
-                    {
-                        "name": "user_id",
-                        "description": "employee ID",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "format": "url",
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "description": "Scan uploaded response, \nLocation header returns scan URL"
-                    },
-                    "400": {
-                        "$ref": "#/components/responses/BadRequest"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/UnauthorizedError"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": []
-                    }
-                ],
-                "operationId": "uploadScan",
-                "description": "Creates a new employee's document scan"
-            }
-        },
         "/login": {
             "post": {
                 "requestBody": {
@@ -583,11 +2147,11 @@
                                 "type": "object",
                                 "properties": {
                                     "login": {
-                                        "description": "employee login",
+                                        "description": "employee login (email)",
                                         "maxLength": 15,
                                         "minLength": 5,
                                         "type": "string",
-                                        "example": "anna"
+                                        "example": "anna@gazneft.ru"
                                     },
                                     "password": {
                                         "format": "password",
@@ -610,9 +2174,9 @@
                                     "type": "object",
                                     "properties": {
                                         "token": {
-                                            "description": "Bearer Token for further authentication",
+                                            "description": "PASETO Bearer Token for further authentication",
                                             "type": "string",
-                                            "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+                                            "example": "v4.public.eyJkYXRhIjoidGhpcyBpcyBhIHNpZ25lZCBtZXNzYWdlIiwiZXhwIjoiMjAyMi0wMS0wMVQwMDowMDowMCswMDowMCJ9v3Jt8mx_TdM2ceTGoqwrh4yDFn0XsHvvV_D0DtwQxVrJEBMl0F2caAdgnpKlt4p7xBnx1HcO-SPo8FPp214HDw.eyJraWQiOiJ6VmhNaVBCUDlmUmYyc25FY1Q3Z0ZUaW9lQTlDT2NOeTlEZmdMMVc2MGhhTiJ9"
                                         }
                                     }
                                 }
@@ -628,971 +2192,8 @@
                     }
                 },
                 "operationId": "login",
-                "description": "Authenticates a user and returns a bearer token on success"
+                "description": "Authenticates a user and returns a paseto bearer token on success"
             }
-        },
-        "/users": {
-            "get": {
-                "parameters": [
-                    {
-                        "examples": {
-                            "Limit example": {
-                                "value": "50"
-                            }
-                        },
-                        "name": "limit",
-                        "description": "maximum number of results to return",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "query",
-                        "required": false
-                    },
-                    {
-                        "examples": {
-                            "Query": {
-                                "value": "\"Иванов\""
-                            }
-                        },
-                        "name": "query",
-                        "description": "query to find by",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "in": "query"
-                    },
-                    {
-                        "examples": {
-                            "Page example": {
-                                "value": "2"
-                            }
-                        },
-                        "name": "page",
-                        "description": "page number with results to return",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "query"
-                    },
-                    {
-                        "examples": {
-                            "SortByExample": {
-                                "value": "\"alphabet\""
-                            }
-                        },
-                        "name": "sort_by",
-                        "description": "type of sort result by",
-                        "schema": {
-                            "enum": [
-                                "alphabet",
-                                "department"
-                            ],
-                            "type": "string"
-                        },
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/GetShortUser"
-                                    }
-                                },
-                                "examples": {
-                                    "List employees example": {
-                                        "value": [
-                                            {
-                                                "first_name": "Alexander",
-                                                "last_name": "Pushkin",
-                                                "middle_name": "Sergeyevich",
-                                                "position": "Novelist",
-                                                "department": "Collegium of Foreign Affairs",
-                                                "email": "pushkin@dantes.net",
-                                                "phone_numbers": [
-                                                    {
-                                                        "number": "799183712345",
-                                                        "type": "mobile"
-                                                    },
-                                                    {
-                                                        "number": "1837",
-                                                        "type": "office"
-                                                    }
-                                                ]
-                                            },
-                                            {
-                                                "first_name": "Nikolai",
-                                                "last_name": "Gogol",
-                                                "middle_name": "Vasilievich",
-                                                "position": "Playwright",
-                                                "department": "Third Section of His Imperial Majesty's Own Chancellery",
-                                                "email": "gogol@fire.net",
-                                                "phone_numbers": [
-                                                    {
-                                                        "number": "799185212345",
-                                                        "type": "mobile"
-                                                    },
-                                                    {
-                                                        "number": "1821",
-                                                        "type": "office"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            }
-                        },
-                        "description": "Employees list response"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/UnauthorizedError"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": []
-                    }
-                ],
-                "operationId": "listUsers",
-                "description": "Returns list of company employees sorted alphabetically (default) or by department"
-            },
-            "post": {
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PostFullUser"
-                            },
-                            "examples": {
-                                "Post employee example": {
-                                    "value": {
-                                        "first_name": "Alexander",
-                                        "last_name": "Pushkin",
-                                        "middle_name": "Sergeyevich",
-                                        "position": "Novelist",
-                                        "department": "Collegium of Foreign Affairs",
-                                        "email": "pushkin@dantes.net",
-                                        "phone_numbers": [
-                                            {
-                                                "number": "799183712345",
-                                                "type": "mobile"
-                                            },
-                                            {
-                                                "number": "1837",
-                                                "type": "office"
-                                            }
-                                        ],
-                                        "foreign_languages": [
-                                            "english",
-                                            "german"
-                                        ],
-                                        "military": {
-                                            "rank": "Старший лейтенант",
-                                            "speciality": "101182",
-                                            "category": "А2",
-                                            "comissariat": "Военный комиссариат Петроградского района г. Санкт-Петербурга"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "201": {
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "format": "url",
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "description": "Employee created response, \nLocation header returns a new employee URL"
-                    },
-                    "400": {
-                        "$ref": "#/components/responses/BadRequest"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/UnauthorizedError"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": []
-                    }
-                ],
-                "operationId": "addUser",
-                "description": "Creates a new employe in the company"
-            }
-        },
-        "/users/{user_id}/passports/{passport_id}": {
-            "get": {
-                "parameters": [
-                    {
-                        "name": "user_id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "name": "passport_id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/GetPassport"
-                                },
-                                "examples": {
-                                    "Foreigners passport example": {
-                                        "value": {
-                                            "id": 75,
-                                            "visas": [
-                                                {
-                                                    "id": 3,
-                                                    "number": "33592222",
-                                                    "issued_state": "Russia",
-                                                    "valid_to": "2017-09-22",
-                                                    "valid_from": "2018-09-22",
-                                                    "number_entries": "mult",
-                                                    "has_scan": true
-                                                }
-                                            ],
-                                            "number": "33592222",
-                                            "issued_date": "2016-05-15",
-                                            "issued_by": "Washington D.C. U.S.A.",
-                                            "type": "foreigners",
-                                            "has_scan": false
-                                        }
-                                    },
-                                    "Internal passport example": {
-                                        "value": {
-                                            "id": 98,
-                                            "visas": [
-                                                {
-                                                    "id": 9,
-                                                    "number": "33592222",
-                                                    "issued_state": "Germany",
-                                                    "valid_to": "2017-09-22",
-                                                    "valid_from": "2017-10-08",
-                                                    "number_entries": "2",
-                                                    "has_scan": false
-                                                }
-                                            ],
-                                            "number": "4011364219",
-                                            "issued_date": "2016-05-15",
-                                            "issued_by": "ТП № 28 отдела УФМС России по СПб и ЛО",
-                                            "type": "internal",
-                                            "has_scan": false
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "description": "Employee passport response"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/UnauthorizedError"
-                    },
-                    "404": {
-                        "description": "Employee/passport not found response"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": []
-                    }
-                ],
-                "operationId": "getPassport",
-                "description": "Returns the employee's passport based on ID"
-            },
-            "delete": {
-                "parameters": [
-                    {
-                        "name": "user_id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "name": "passport_id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Employee passport deleted response (empty)"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/UnauthorizedError"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": []
-                    }
-                ],
-                "operationId": "deletePassport",
-                "description": "Deletes the employee's passport based on ID"
-            },
-            "patch": {
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchPassport"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "parameters": [
-                    {
-                        "name": "user_id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "name": "passport_id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Employee passport updated response (empty)"
-                    },
-                    "400": {
-                        "$ref": "#/components/responses/BadRequest"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/UnauthorizedError"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": []
-                    }
-                ],
-                "operationId": "patchPassport",
-                "description": "Changes selected fields in the employee's passport structure based on ID"
-            },
-            "parameters": [
-                {
-                    "name": "user_id",
-                    "schema": {
-                        "type": "integer"
-                    },
-                    "in": "path",
-                    "required": true
-                },
-                {
-                    "name": "passport_id",
-                    "schema": {
-                        "type": "integer"
-                    },
-                    "in": "path",
-                    "required": true
-                }
-            ]
-        },
-        "/users/{user_id}/passports/{passport_id}/visas/{visa_id}": {
-            "get": {
-                "parameters": [
-                    {
-                        "name": "user_id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "name": "passport_id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "name": "visa_id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/GetVisa"
-                                }
-                            }
-                        },
-                        "description": "Employee visa response"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/UnauthorizedError"
-                    },
-                    "404": {
-                        "description": "Employee/passport/visa not found response"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": []
-                    }
-                ],
-                "operationId": "getVisa",
-                "description": "Returns the employee's visa based on ID"
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Employee visa deleted response (empty)"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/UnauthorizedError"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": []
-                    }
-                ],
-                "operationId": "deleteVisa",
-                "description": "Deletes the employee's visa based on ID"
-            },
-            "patch": {
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchVisa"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "parameters": [
-                    {
-                        "name": "user_id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "name": "passport_id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "name": "visa_id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Employee visa updated response (empty)"
-                    },
-                    "400": {
-                        "$ref": "#/components/responses/BadRequest"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/UnauthorizedError"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": []
-                    }
-                ],
-                "operationId": "patchVisa",
-                "description": "Changes selected fields in the employee's visa structure based on ID"
-            },
-            "parameters": [
-                {
-                    "name": "user_id",
-                    "schema": {
-                        "type": "integer"
-                    },
-                    "in": "path",
-                    "required": true
-                },
-                {
-                    "name": "passport_id",
-                    "schema": {
-                        "type": "integer"
-                    },
-                    "in": "path",
-                    "required": true
-                },
-                {
-                    "name": "visa_id",
-                    "schema": {
-                        "type": "integer"
-                    },
-                    "in": "path",
-                    "required": true
-                }
-            ]
-        },
-        "/users/{user_id}/contracts": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/GetContract"
-                                    }
-                                }
-                            }
-                        },
-                        "description": "Employee contracts list response"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/UnauthorizedError"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": []
-                    }
-                ],
-                "operationId": "listContracts",
-                "description": "Returns list of employee's contracts"
-            },
-            "post": {
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PostContract"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "201": {
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "format": "url",
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "description": "Employee contract added response,\nLocation header returns a new employee contract URL"
-                    },
-                    "400": {
-                        "$ref": "#/components/responses/BadRequest"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/UnauthorizedError"
-                    },
-                    "409": {
-                        "description": "Add contract conflict response: the contract already exists"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": []
-                    }
-                ],
-                "operationId": "addContract",
-                "description": "Creates a new employee's contract"
-            },
-            "parameters": [
-                {
-                    "name": "user_id",
-                    "schema": {
-                        "type": "integer"
-                    },
-                    "in": "path",
-                    "required": true
-                }
-            ]
-        },
-        "/users/{user_id}/passports": {
-            "get": {
-                "parameters": [
-                    {
-                        "name": "user_id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/GetPassport"
-                                    }
-                                }
-                            }
-                        },
-                        "description": "List employee passports"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/UnauthorizedError"
-                    },
-                    "404": {
-                        "description": "Employee not found response"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": []
-                    }
-                ],
-                "operationId": "listPassports",
-                "description": "Returns list of employee's passport"
-            },
-            "post": {
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PostPassport"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "parameters": [
-                    {
-                        "name": "user_id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "format": "url",
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "description": "Passport added response, \nLocation header returns a new employee passport URL"
-                    },
-                    "400": {
-                        "$ref": "#/components/responses/BadRequest"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/UnauthorizedError"
-                    },
-                    "409": {
-                        "description": "Add passport conflict response: the passport already exists"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": []
-                    }
-                ],
-                "operationId": "addPassport",
-                "description": "Creates a new employee's passport"
-            }
-        },
-        "/users/{user_id}/passports/{passport_id}/visas": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/GetVisa"
-                                    }
-                                }
-                            }
-                        },
-                        "description": "List employee visas for this passport"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/UnauthorizedError"
-                    },
-                    "404": {
-                        "description": "Employee/passport not found response"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": []
-                    }
-                ],
-                "operationId": "listVisas",
-                "description": "Returns list of employee's visas"
-            },
-            "post": {
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PostVisa"
-                            },
-                            "examples": {
-                                "New visa example": {
-                                    "value": {
-                                        "number": "33592222",
-                                        "issued_state": "Spain",
-                                        "valid_to": "2017-09-22",
-                                        "valid_from": "2017-10-08",
-                                        "number_entries": "1"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "201": {
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "format": "url",
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "description": "Employee visa added response,\nLocation header returns a new employee visa URL"
-                    },
-                    "400": {
-                        "$ref": "#/components/responses/BadRequest"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/UnauthorizedError"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": []
-                    }
-                ],
-                "operationId": "addVisa",
-                "description": "Creates a new employee's visa"
-            },
-            "parameters": [
-                {
-                    "name": "user_id",
-                    "schema": {
-                        "type": "integer"
-                    },
-                    "in": "path",
-                    "required": true
-                },
-                {
-                    "name": "passport_id",
-                    "schema": {
-                        "type": "integer"
-                    },
-                    "in": "path",
-                    "required": true
-                }
-            ]
-        },
-        "/users/{user_id}/contracts/{contract_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/GetContract"
-                                }
-                            }
-                        },
-                        "description": "Employee contract response"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/UnauthorizedError"
-                    },
-                    "404": {
-                        "description": "Employee/contract not found response"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": []
-                    }
-                ],
-                "operationId": "getContract",
-                "description": "Returns the employee's contract based on ID"
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Employee contract deleted response (empty)"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/UnauthorizedError"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": []
-                    }
-                ],
-                "operationId": "deleteContract",
-                "description": "Deletes the employee's contract based on ID"
-            },
-            "patch": {
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchContract"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Employee contract updated response (empty)"
-                    },
-                    "400": {
-                        "$ref": "#/components/responses/BadRequest"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/UnauthorizedError"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": []
-                    }
-                ],
-                "operationId": "patchContract",
-                "description": "Changes selected fields in the employee's contract structure based on ID"
-            },
-            "parameters": [
-                {
-                    "name": "user_id",
-                    "schema": {
-                        "type": "integer"
-                    },
-                    "in": "path",
-                    "required": true
-                },
-                {
-                    "name": "contract_id",
-                    "schema": {
-                        "type": "integer"
-                    },
-                    "in": "path",
-                    "required": true
-                }
-            ]
         },
         "/login/change-password": {
             "get": {
@@ -1618,7 +2219,7 @@
                         "description": "Check a change password key response (empty)"
                     },
                     "400": {
-                        "description": "Invalid recovery key"
+                        "$ref": "#/components/responses/BadRequest"
                     },
                     "429": {
                         "description": "Too many request response"
@@ -1654,7 +2255,7 @@
                         "description": "Change password response (empty)"
                     },
                     "400": {
-                        "description": "Invalid recovery key or password"
+                        "$ref": "#/components/responses/BadRequest"
                     },
                     "404": {
                         "description": "Employee not found"
@@ -1669,195 +2270,6 @@
                 "operationId": "changePassword",
                 "description": "Accepts a login and sends the key to change the password to the user's email. \nOr it accepts the key and a new password and changes it."
             }
-        },
-        "/users/{user_id}/vacations/{vacation_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/GetVacation"
-                                }
-                            }
-                        },
-                        "description": "Employee vacation response"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/UnauthorizedError"
-                    },
-                    "404": {
-                        "description": "Employee/vacation not found response"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": []
-                    }
-                ],
-                "operationId": "getVacation",
-                "description": "Returns the employee's vacation based on ID"
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Vacation deleted response (empty)"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/UnauthorizedError"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": []
-                    }
-                ],
-                "operationId": "deleteVacation",
-                "description": "Deletes the employee's vacation based on ID"
-            },
-            "patch": {
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchVacation"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Vacation updated response"
-                    },
-                    "400": {
-                        "$ref": "#/components/responses/BadRequest"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/UnauthorizedError"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": []
-                    }
-                ],
-                "operationId": "patchVacation",
-                "description": "Changes selected fields in the employee's vacation structure based on ID"
-            },
-            "parameters": [
-                {
-                    "name": "user_id",
-                    "schema": {
-                        "type": "integer"
-                    },
-                    "in": "path",
-                    "required": true
-                },
-                {
-                    "name": "vacation_id",
-                    "schema": {
-                        "type": "integer"
-                    },
-                    "in": "path",
-                    "required": true
-                }
-            ]
-        },
-        "/users/{user_id}/vacations": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/GetVacation"
-                                    }
-                                }
-                            }
-                        },
-                        "description": "Employee vacations list response"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/UnauthorizedError"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": []
-                    }
-                ],
-                "operationId": "listVacations",
-                "description": "Returns list of employee's vacations"
-            },
-            "post": {
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PostVacation"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "201": {
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "format": "url",
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "description": "Employee vacation added response, \nLocation header returns vacation URL"
-                    },
-                    "400": {
-                        "$ref": "#/components/responses/BadRequest"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/UnauthorizedError"
-                    },
-                    "409": {
-                        "description": "Add vacation conflict response: the dates indicated conflict with the available ones"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": []
-                    }
-                ],
-                "operationId": "postVacation",
-                "description": "Creates a new employee's vacation"
-            },
-            "parameters": [
-                {
-                    "name": "user_id",
-                    "schema": {
-                        "type": "integer"
-                    },
-                    "in": "path",
-                    "required": true
-                }
-            ]
         }
     },
     "components": {
@@ -1920,570 +2332,6 @@
                     "other"
                 ],
                 "type": "string"
-            },
-            "BaseVisa": {
-                "description": "",
-                "required": [],
-                "type": "object",
-                "properties": {
-                    "number": {
-                        "description": "",
-                        "maxLength": 50,
-                        "minLength": 2,
-                        "type": "string"
-                    },
-                    "issued_state": {
-                        "description": "",
-                        "maxLength": 50,
-                        "minLength": 2,
-                        "type": "string"
-                    },
-                    "valid_to": {
-                        "format": "date",
-                        "description": "",
-                        "maxLength": 10,
-                        "minLength": 10,
-                        "type": "string"
-                    },
-                    "valid_from": {
-                        "format": "date",
-                        "description": "",
-                        "maxLength": 10,
-                        "minLength": 10,
-                        "type": "string"
-                    },
-                    "number_entries": {
-                        "description": "",
-                        "enum": [
-                            "1",
-                            "2",
-                            "mult"
-                        ],
-                        "type": "string"
-                    }
-                },
-                "example": {
-                    "number": "33592222",
-                    "issued_state": "Spain",
-                    "valid_to": "2017-10-22",
-                    "valid_from": "2017-09-08",
-                    "number_entries": "1"
-                }
-            },
-            "BaseScan": {
-                "description": "",
-                "required": [],
-                "type": "object",
-                "properties": {
-                    "type": {
-                        "$ref": "#/components/schemas/ScanType",
-                        "description": ""
-                    },
-                    "description": {
-                        "description": "",
-                        "type": "string"
-                    },
-                    "document_id": {
-                        "description": "document ID (if necessary), passport ID for passport scan, for example",
-                        "type": "integer"
-                    }
-                }
-            },
-            "GetScan": {
-                "description": "",
-                "required": [
-                    "id",
-                    "type",
-                    "upload_at"
-                ],
-                "type": "object",
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/BaseScan"
-                    }
-                ],
-                "properties": {
-                    "id": {
-                        "description": "",
-                        "type": "integer"
-                    },
-                    "upload_at": {
-                        "format": "date-time",
-                        "description": "",
-                        "maxLength": 32,
-                        "minLength": 21,
-                        "type": "string"
-                    }
-                }
-            },
-            "BaseShortUser": {
-                "required": [],
-                "properties": {
-                    "first_name": {
-                        "description": "",
-                        "maxLength": 150,
-                        "minLength": 2,
-                        "type": "string"
-                    },
-                    "last_name": {
-                        "maxLength": 150,
-                        "minLength": 2,
-                        "type": "string"
-                    },
-                    "middle_name": {
-                        "description": "",
-                        "maxLength": 150,
-                        "minLength": 2,
-                        "type": "string"
-                    },
-                    "position": {
-                        "description": "",
-                        "maxLength": 150,
-                        "minLength": 2,
-                        "type": "string"
-                    },
-                    "department": {
-                        "description": "",
-                        "maxLength": 150,
-                        "minLength": 2,
-                        "type": "string"
-                    },
-                    "email": {
-                        "format": "email",
-                        "description": "",
-                        "maxLength": 50,
-                        "minLength": 2,
-                        "type": "string"
-                    },
-                    "phone_numbers": {
-                        "$ref": "#/components/schemas/PhoneNumbers",
-                        "description": "",
-                        "maxLength": 15,
-                        "minLength": 2
-                    }
-                },
-                "example": {
-                    "first_name": "Alexander",
-                    "last_name": "Pushkin",
-                    "middle_name": "Sergeyevich",
-                    "position": "Novelist",
-                    "department": "Collegium of Foreign Affairs",
-                    "email": "pushkin@dantes.net",
-                    "phone_numbers": [
-                        {
-                            "number": "799183712345",
-                            "type": "mobile"
-                        },
-                        {
-                            "number": "1837",
-                            "type": "office"
-                        }
-                    ]
-                }
-            },
-            "GetShortUser": {
-                "description": "",
-                "required": [
-                    "id",
-                    "first_name",
-                    "last_name"
-                ],
-                "type": "object",
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/BaseShortUser"
-                    }
-                ],
-                "properties": {
-                    "id": {
-                        "description": "",
-                        "type": "integer"
-                    }
-                }
-            },
-            "BaseFullUser": {
-                "required": [],
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/BaseShortUser"
-                    },
-                    {
-                        "required": [
-                            "id"
-                        ]
-                    }
-                ],
-                "properties": {
-                    "grade": {
-                        "description": "",
-                        "maxLength": 1,
-                        "minLength": 1,
-                        "type": "string"
-                    },
-                    "date_of_birth": {
-                        "format": "date",
-                        "description": "",
-                        "maxLength": 10,
-                        "minLength": 10,
-                        "type": "string"
-                    },
-                    "place_of_birth": {
-                        "description": "",
-                        "maxLength": 150,
-                        "minLength": 2,
-                        "type": "string"
-                    },
-                    "registration_address": {
-                        "description": "",
-                        "maxLength": 150,
-                        "minLength": 2,
-                        "type": "string"
-                    },
-                    "residential_address": {
-                        "description": "",
-                        "maxLength": 150,
-                        "minLength": 2,
-                        "type": "string"
-                    },
-                    "nationality": {
-                        "description": "",
-                        "maxLength": 150,
-                        "minLength": 2,
-                        "type": "string"
-                    },
-                    "foreign_languages": {
-                        "description": "",
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "military": {
-                        "$ref": "#/components/schemas/Military",
-                        "description": ""
-                    },
-                    "taxpayer": {
-                        "$ref": "#/components/schemas/Taxpayer",
-                        "description": "",
-                        "maxLength": 12,
-                        "minLength": 10
-                    },
-                    "insurance": {
-                        "$ref": "#/components/schemas/Insurance",
-                        "description": "",
-                        "maxLength": 11,
-                        "minLength": 11
-                    },
-                    "work_permit": {
-                        "$ref": "#/components/schemas/WorkPermit",
-                        "description": ""
-                    }
-                },
-                "example": {
-                    "grade": "1",
-                    "date_of_birth": "2018-01-17",
-                    "place_of_birth": "Москва",
-                    "registration_address": "Санкт-Петербург, наб. реки Мойки, 12",
-                    "residential_address": "Санкт-Петербург, наб. реки Мойки, 12",
-                    "nationality": "Царская Россия",
-                    "foreign_languages": [
-                        "english",
-                        "french"
-                    ],
-                    "military": {
-                        "rank": "Старший лейтенант",
-                        "speciality": "101182",
-                        "category": "А2",
-                        "comissariat": "Военный комиссариат Петроградского района г. Санкт-Петербурга",
-                        "has_scan": true
-                    },
-                    "taxpayer": {
-                        "number": "500100732259",
-                        "has_scan": true
-                    },
-                    "insurance": {
-                        "number": "08336732477",
-                        "has_scan": true
-                    }
-                }
-            },
-            "GetFullUser": {
-                "description": "",
-                "required": [
-                    "id",
-                    "date_of_birth",
-                    "first_name",
-                    "last_name"
-                ],
-                "type": "object",
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/BaseFullUser"
-                    }
-                ],
-                "properties": {
-                    "id": {
-                        "description": "",
-                        "type": "integer"
-                    },
-                    "passports": {
-                        "description": "",
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/GetPassport"
-                        }
-                    },
-                    "contracts": {
-                        "description": "",
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/BaseContract"
-                        }
-                    },
-                    "vacations": {
-                        "description": "",
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/GetVacation"
-                        }
-                    }
-                }
-            },
-            "PostFullUser": {
-                "description": "",
-                "required": [
-                    "date_of_birth",
-                    "first_name",
-                    "last_name"
-                ],
-                "type": "object",
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/BaseFullUser"
-                    }
-                ]
-            },
-            "BasePassport": {
-                "description": "",
-                "required": [],
-                "type": "object",
-                "properties": {
-                    "number": {
-                        "description": "",
-                        "maxLength": 50,
-                        "minLength": 2,
-                        "type": "string"
-                    },
-                    "issued_date": {
-                        "description": "",
-                        "maxLength": 8,
-                        "minLength": 8,
-                        "type": "string"
-                    },
-                    "issued_by": {
-                        "description": "",
-                        "maxLength": 150,
-                        "minLength": 2,
-                        "type": "string"
-                    },
-                    "type": {
-                        "description": "",
-                        "enum": [
-                            "internal",
-                            "external",
-                            "foreigners"
-                        ],
-                        "type": "string"
-                    }
-                },
-                "example": {
-                    "number": "33592222",
-                    "issued_date": "2016-05-15",
-                    "issued_by": "Washington D.C. U.S.A.",
-                    "type": "foreigners"
-                }
-            },
-            "PostPassport": {
-                "description": "",
-                "required": [
-                    "number",
-                    "issued_date",
-                    "issued_by",
-                    "type"
-                ],
-                "type": "object",
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/BasePassport"
-                    }
-                ]
-            },
-            "PatchFullUser": {
-                "description": "",
-                "type": "object",
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/BaseFullUser"
-                    }
-                ]
-            },
-            "PatchPassport": {
-                "description": "",
-                "type": "object",
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/BasePassport"
-                    }
-                ]
-            },
-            "PostVisa": {
-                "description": "",
-                "required": [
-                    "number",
-                    "issued_state",
-                    "valid_to",
-                    "valid_from",
-                    "number_entries"
-                ],
-                "type": "object",
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/BaseVisa"
-                    }
-                ]
-            },
-            "PatchVisa": {
-                "description": "",
-                "type": "object",
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/BaseVisa"
-                    }
-                ]
-            },
-            "BaseContract": {
-                "description": "",
-                "required": [],
-                "type": "object",
-                "properties": {
-                    "date_from": {
-                        "format": "date",
-                        "description": "",
-                        "maxLength": 10,
-                        "minLength": 10,
-                        "type": "string"
-                    },
-                    "date_to": {
-                        "format": "date",
-                        "description": "",
-                        "maxLength": 10,
-                        "minLength": 10,
-                        "type": "string"
-                    },
-                    "type": {
-                        "description": "",
-                        "enum": [
-                            "temporary",
-                            "permanent"
-                        ],
-                        "type": "string"
-                    },
-                    "number": {
-                        "description": "",
-                        "maxLength": 50,
-                        "minLength": 2,
-                        "type": "string"
-                    }
-                },
-                "example": {
-                    "date_from": "2018-01-17",
-                    "date_to": "2020-01-17",
-                    "type": "temporary",
-                    "number": "145678"
-                }
-            },
-            "GetContract": {
-                "description": "",
-                "required": [
-                    "id",
-                    "date_from",
-                    "number",
-                    "type",
-                    "has_scan"
-                ],
-                "type": "object",
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/BaseContract"
-                    }
-                ],
-                "properties": {
-                    "id": {
-                        "description": "",
-                        "type": "integer"
-                    },
-                    "has_scan": {
-                        "description": "",
-                        "type": "boolean"
-                    }
-                }
-            },
-            "PostContract": {
-                "description": "",
-                "required": [
-                    "date_from",
-                    "number",
-                    "type"
-                ],
-                "type": "object",
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/BaseContract"
-                    }
-                ]
-            },
-            "PatchContract": {
-                "description": "",
-                "type": "object",
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/BaseContract"
-                    }
-                ]
-            },
-            "GetPassport": {
-                "description": "",
-                "required": [
-                    "id",
-                    "has_scan",
-                    "number",
-                    "issued_date",
-                    "issued_by",
-                    "type"
-                ],
-                "type": "object",
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/BasePassport"
-                    }
-                ],
-                "properties": {
-                    "id": {
-                        "description": "",
-                        "type": "integer"
-                    },
-                    "has_scan": {
-                        "description": "",
-                        "type": "boolean"
-                    },
-                    "visas": {
-                        "description": "",
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/GetVisa"
-                        }
-                    }
-                }
             },
             "Military": {
                 "description": "",
@@ -2577,52 +2425,6 @@
                     "has_scan": true
                 }
             },
-            "GetVisa": {
-                "description": "",
-                "required": [
-                    "id",
-                    "number",
-                    "issued_state",
-                    "valid_to",
-                    "valid_from",
-                    "number_entries",
-                    "has_scan"
-                ],
-                "type": "object",
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/BaseVisa"
-                    }
-                ],
-                "properties": {
-                    "id": {
-                        "description": "",
-                        "type": "integer"
-                    },
-                    "has_scan": {
-                        "description": "",
-                        "type": "boolean"
-                    }
-                }
-            },
-            "ChangePasswordLogin": {
-                "description": "",
-                "required": [
-                    "login"
-                ],
-                "type": "object",
-                "properties": {
-                    "login": {
-                        "description": "employee login",
-                        "maxLength": 15,
-                        "minLength": 5,
-                        "type": "string"
-                    }
-                },
-                "example": {
-                    "login": "VasyaPP"
-                }
-            },
             "ChangePasswordPassword": {
                 "description": "",
                 "required": [
@@ -2667,15 +2469,11 @@
                     "valid_to": {
                         "format": "date",
                         "description": "",
-                        "maxLength": 10,
-                        "minLength": 10,
                         "type": "string"
                     },
                     "valid_from": {
                         "format": "date",
                         "description": "",
-                        "maxLength": 10,
-                        "minLength": 10,
                         "type": "string"
                     },
                     "has_scan": {
@@ -2690,74 +2488,6 @@
                     "has_scan": true
                 }
             },
-            "BaseVacation": {
-                "description": "",
-                "required": [],
-                "type": "object",
-                "properties": {
-                    "date_from": {
-                        "format": "date",
-                        "description": "",
-                        "maxLength": 10,
-                        "minLength": 10,
-                        "type": "string"
-                    },
-                    "date_to": {
-                        "format": "date",
-                        "description": "",
-                        "maxLength": 10,
-                        "minLength": 10,
-                        "type": "string"
-                    }
-                }
-            },
-            "PostVacation": {
-                "description": "",
-                "required": [
-                    "date_to",
-                    "date_from"
-                ],
-                "type": "object",
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/BaseVacation"
-                    }
-                ]
-            },
-            "PatchVacation": {
-                "description": "",
-                "type": "object",
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/BaseVacation"
-                    }
-                ]
-            },
-            "GetVacation": {
-                "description": "",
-                "required": [
-                    "id",
-                    "date_from",
-                    "date_to"
-                ],
-                "type": "object",
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/BaseVacation"
-                    }
-                ],
-                "properties": {
-                    "id": {
-                        "description": "",
-                        "type": "integer"
-                    }
-                },
-                "example": {
-                    "id": 78,
-                    "date_from": "2018-03-11",
-                    "date_to": "2018-03-25"
-                }
-            },
             "Error": {
                 "required": [
                     "message"
@@ -2770,6 +2500,399 @@
                     "message": {
                         "type": "string"
                     }
+                }
+            },
+            "Contract": {
+                "description": "",
+                "required": [],
+                "type": "object",
+                "properties": {
+                    "date_from": {
+                        "format": "date",
+                        "description": "",
+                        "type": "string"
+                    },
+                    "date_to": {
+                        "format": "date",
+                        "description": "",
+                        "type": "string"
+                    },
+                    "type": {
+                        "description": "",
+                        "enum": [
+                            "temporary",
+                            "permanent"
+                        ],
+                        "type": "string"
+                    },
+                    "number": {
+                        "description": "",
+                        "maxLength": 50,
+                        "minLength": 2,
+                        "type": "string"
+                    },
+                    "id": {
+                        "description": "",
+                        "type": "integer"
+                    },
+                    "has_scan": {
+                        "description": "",
+                        "type": "boolean",
+                        "readOnly": true
+                    }
+                },
+                "example": {
+                    "id": 127,
+                    "has_scan": true,
+                    "date_from": "2018-01-17",
+                    "date_to": "2020-01-17",
+                    "type": "temporary",
+                    "number": "145678"
+                }
+            },
+            "Passport": {
+                "description": "",
+                "required": [],
+                "type": "object",
+                "properties": {
+                    "number": {
+                        "description": "",
+                        "maxLength": 50,
+                        "minLength": 2,
+                        "type": "string"
+                    },
+                    "issued_date": {
+                        "description": "",
+                        "maxLength": 8,
+                        "minLength": 8,
+                        "type": "string"
+                    },
+                    "issued_by": {
+                        "description": "",
+                        "maxLength": 150,
+                        "minLength": 2,
+                        "type": "string"
+                    },
+                    "type": {
+                        "description": "",
+                        "enum": [
+                            "internal",
+                            "external",
+                            "foreigners"
+                        ],
+                        "type": "string"
+                    },
+                    "id": {
+                        "description": "",
+                        "type": "integer"
+                    },
+                    "has_scan": {
+                        "description": "",
+                        "type": "boolean",
+                        "readOnly": true
+                    }
+                },
+                "example": {
+                    "id": 547,
+                    "has_scan": false,
+                    "number": "33592222",
+                    "issued_date": "2016-05-15",
+                    "issued_by": "Washington D.C. U.S.A.",
+                    "type": "foreigners"
+                }
+            },
+            "Visa": {
+                "description": "",
+                "required": [],
+                "type": "object",
+                "properties": {
+                    "number": {
+                        "description": "",
+                        "maxLength": 50,
+                        "minLength": 2,
+                        "type": "string"
+                    },
+                    "issued_state": {
+                        "description": "",
+                        "maxLength": 50,
+                        "minLength": 2,
+                        "type": "string"
+                    },
+                    "valid_to": {
+                        "format": "date",
+                        "description": "",
+                        "type": "string"
+                    },
+                    "valid_from": {
+                        "format": "date",
+                        "description": "",
+                        "type": "string"
+                    },
+                    "number_entries": {
+                        "description": "",
+                        "enum": [
+                            "1",
+                            "2",
+                            "mult"
+                        ],
+                        "type": "string"
+                    },
+                    "id": {
+                        "description": "",
+                        "type": "integer"
+                    },
+                    "has_scan": {
+                        "description": "",
+                        "type": "boolean",
+                        "readOnly": true
+                    }
+                },
+                "example": {
+                    "id": 512,
+                    "has_scan": true,
+                    "number": "33592222",
+                    "issued_state": "Spain",
+                    "valid_to": "2017-10-22",
+                    "valid_from": "2017-09-08",
+                    "number_entries": "1"
+                }
+            },
+            "ShortUser": {
+                "required": [],
+                "properties": {
+                    "first_name": {
+                        "description": "",
+                        "maxLength": 150,
+                        "minLength": 2,
+                        "type": "string"
+                    },
+                    "last_name": {
+                        "maxLength": 150,
+                        "minLength": 2,
+                        "type": "string"
+                    },
+                    "middle_name": {
+                        "description": "",
+                        "maxLength": 150,
+                        "minLength": 2,
+                        "type": "string"
+                    },
+                    "position": {
+                        "description": "",
+                        "maxLength": 150,
+                        "minLength": 2,
+                        "type": "string"
+                    },
+                    "department": {
+                        "description": "",
+                        "maxLength": 150,
+                        "minLength": 2,
+                        "type": "string"
+                    },
+                    "email": {
+                        "format": "email",
+                        "description": "",
+                        "maxLength": 50,
+                        "minLength": 2,
+                        "type": "string"
+                    },
+                    "phone_numbers": {
+                        "$ref": "#/components/schemas/PhoneNumbers",
+                        "description": "",
+                        "maxLength": 15,
+                        "minLength": 2
+                    },
+                    "id": {
+                        "description": "",
+                        "type": "integer"
+                    }
+                },
+                "example": {
+                    "id": 1,
+                    "first_name": "Alexander",
+                    "last_name": "Pushkin",
+                    "middle_name": "Sergeyevich",
+                    "position": "Novelist",
+                    "department": "Collegium of Foreign Affairs",
+                    "email": "pushkin@dantes.net",
+                    "phone_numbers": [
+                        {
+                            "number": "799183712345",
+                            "type": "mobile"
+                        },
+                        {
+                            "number": "1837",
+                            "type": "office"
+                        }
+                    ]
+                }
+            },
+            "FullUser": {
+                "required": [],
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/ShortUser"
+                    }
+                ],
+                "properties": {
+                    "grade": {
+                        "description": "",
+                        "maxLength": 1,
+                        "minLength": 1,
+                        "type": "string"
+                    },
+                    "date_of_birth": {
+                        "format": "date",
+                        "description": "",
+                        "type": "string"
+                    },
+                    "place_of_birth": {
+                        "description": "",
+                        "maxLength": 150,
+                        "minLength": 2,
+                        "type": "string"
+                    },
+                    "registration_address": {
+                        "description": "",
+                        "maxLength": 150,
+                        "minLength": 2,
+                        "type": "string"
+                    },
+                    "residential_address": {
+                        "description": "",
+                        "maxLength": 150,
+                        "minLength": 2,
+                        "type": "string"
+                    },
+                    "nationality": {
+                        "description": "",
+                        "maxLength": 150,
+                        "minLength": 2,
+                        "type": "string"
+                    },
+                    "foreign_languages": {
+                        "description": "",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "military": {
+                        "$ref": "#/components/schemas/Military",
+                        "description": ""
+                    },
+                    "taxpayer": {
+                        "$ref": "#/components/schemas/Taxpayer",
+                        "description": "",
+                        "maxLength": 12,
+                        "minLength": 10
+                    },
+                    "insurance": {
+                        "$ref": "#/components/schemas/Insurance",
+                        "description": "",
+                        "maxLength": 11,
+                        "minLength": 11
+                    },
+                    "work_permit": {
+                        "$ref": "#/components/schemas/WorkPermit",
+                        "description": ""
+                    }
+                },
+                "example": {
+                    "grade": "1",
+                    "date_of_birth": "2018-01-17",
+                    "place_of_birth": "Москва",
+                    "registration_address": "Санкт-Петербург, наб. реки Мойки, 12",
+                    "residential_address": "Санкт-Петербург, наб. реки Мойки, 12",
+                    "nationality": "Царская Россия",
+                    "foreign_languages": [
+                        "english",
+                        "french"
+                    ],
+                    "military": {
+                        "rank": "Старший лейтенант",
+                        "speciality": "101182",
+                        "category": "А2",
+                        "comissariat": "Военный комиссариат Петроградского района г. Санкт-Петербурга",
+                        "has_scan": true
+                    },
+                    "taxpayer": {
+                        "number": "500100732259",
+                        "has_scan": true
+                    },
+                    "insurance": {
+                        "number": "08336732477",
+                        "has_scan": true
+                    }
+                }
+            },
+            "Vacation": {
+                "description": "",
+                "required": [],
+                "type": "object",
+                "properties": {
+                    "date_from": {
+                        "format": "date",
+                        "description": "",
+                        "type": "string"
+                    },
+                    "date_to": {
+                        "format": "date",
+                        "description": "",
+                        "type": "string"
+                    },
+                    "id": {
+                        "description": "",
+                        "type": "integer"
+                    }
+                }
+            },
+            "Scan": {
+                "description": "",
+                "required": [],
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "$ref": "#/components/schemas/ScanType",
+                        "description": ""
+                    },
+                    "description": {
+                        "description": "",
+                        "type": "string"
+                    },
+                    "document_id": {
+                        "description": "document ID (if necessary), passport ID for passport scan, for example",
+                        "type": "integer"
+                    },
+                    "id": {
+                        "description": "",
+                        "type": "integer"
+                    },
+                    "upload_at": {
+                        "format": "date-time",
+                        "description": "an upload date-time as defined by full-date - RFC3339",
+                        "type": "string",
+                        "example": "2019-08-24T14:15:22Z"
+                    }
+                }
+            },
+            "ChangePasswordLogin": {
+                "description": "",
+                "required": [
+                    "email"
+                ],
+                "type": "object",
+                "properties": {
+                    "email": {
+                        "format": "email",
+                        "description": "employee login (email)",
+                        "maxLength": 50,
+                        "minLength": 5,
+                        "type": "string"
+                    }
+                },
+                "example": {
+                    "login": "vasyapp&gazneft.ru"
                 }
             }
         },

--- a/api/api.json
+++ b/api/api.json
@@ -2,7 +2,7 @@
     "openapi": "3.0.2",
     "info": {
         "title": "Employee's cabinet",
-        "version": "0.7.3",
+        "version": "0.8.0",
         "description": "",
         "contact": {
             "name": "Yandex Practicum Students Team"
@@ -14,56 +14,6 @@
         }
     ],
     "paths": {
-        "/departments": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Department"
-                                    }
-                                },
-                                "examples": {
-                                    "Departments": {
-                                        "value": [
-                                            {
-                                                "name": "HR department",
-                                                "users_number": 5,
-                                                "selected_users_number": 0,
-                                                "id": 7
-                                            },
-                                            {
-                                                "name": "Accounts department",
-                                                "users_number": 4,
-                                                "selected_users_number": 1,
-                                                "id": 3
-                                            }
-                                        ]
-                                    }
-                                }
-                            }
-                        },
-                        "description": "Departments list response"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/UnauthorizedError"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": []
-                    }
-                ],
-                "operationId": "listDepartments",
-                "description": "Returns a list of company departments with the number of employees"
-            }
-        },
         "/users/{user_id}/photo": {
             "post": {
                 "requestBody": {
@@ -623,158 +573,6 @@
                     "required": true
                 }
             ]
-        },
-        "/users/{user_id}/passports": {
-            "get": {
-                "parameters": [
-                    {
-                        "name": "user_id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "allOf": [
-                                            {
-                                                "$ref": "#/components/schemas/Passport"
-                                            },
-                                            {
-                                                "required": [
-                                                    "id",
-                                                    "number",
-                                                    "issued_date",
-                                                    "issued_by",
-                                                    "type",
-                                                    "has_scan"
-                                                ]
-                                            },
-                                            {
-                                                "type": "object",
-                                                "properties": {
-                                                    "visas": {
-                                                        "description": "",
-                                                        "type": "array",
-                                                        "items": {
-                                                            "allOf": [
-                                                                {
-                                                                    "$ref": "#/components/schemas/Visa"
-                                                                },
-                                                                {
-                                                                    "required": [
-                                                                        "id",
-                                                                        "has_scan",
-                                                                        "number",
-                                                                        "issued_state",
-                                                                        "valid_to",
-                                                                        "valid_from",
-                                                                        "number_entries"
-                                                                    ]
-                                                                }
-                                                            ]
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        ]
-                                    }
-                                }
-                            }
-                        },
-                        "description": "List employee passports"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/UnauthorizedError"
-                    },
-                    "404": {
-                        "description": "Employee not found response"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": []
-                    }
-                ],
-                "operationId": "listPassports",
-                "description": "Returns list of employee's passport"
-            },
-            "post": {
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/Passport"
-                                    },
-                                    {
-                                        "required": [
-                                            "number",
-                                            "issued_date",
-                                            "issued_by",
-                                            "type"
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "parameters": [
-                    {
-                        "name": "user_id",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "format": "uri",
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "description": "Passport added response, \nLocation header returns a new employee passport URL"
-                    },
-                    "400": {
-                        "$ref": "#/components/responses/BadRequest"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/UnauthorizedError"
-                    },
-                    "409": {
-                        "description": "Add passport conflict response: the passport already exists"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": []
-                    }
-                ],
-                "operationId": "addPassport",
-                "description": "Creates a new employee's passport"
-            }
         },
         "/users/{user_id}/passports/{passport_id}": {
             "get": {
@@ -1680,6 +1478,279 @@
                 "description": "Accepts a login and sends the key to change the password to the user's email. \nOr it accepts the key and a new password and changes it."
             }
         },
+        "/users/{user_id}/scans/{scan_id}": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/Scan"
+                                        },
+                                        {
+                                            "required": [
+                                                "id",
+                                                "type",
+                                                "upload_at"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        "description": "Employee document scan response"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "getScan",
+                "description": "Returns the employee's document scan based on ID"
+            },
+            "delete": {
+                "responses": {
+                    "200": {
+                        "description": "Employee scan deleted response (empty)"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "deleteScan",
+                "description": "Deletes the employee's document scan based on ID"
+            },
+            "parameters": [
+                {
+                    "name": "user_id",
+                    "schema": {
+                        "type": "integer"
+                    },
+                    "in": "path",
+                    "required": true
+                },
+                {
+                    "name": "scan_id",
+                    "schema": {
+                        "type": "integer"
+                    },
+                    "in": "path",
+                    "required": true
+                }
+            ]
+        },
+        "/departments": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "allOf": [
+                                            {
+                                                "$ref": "#/components/schemas/Department"
+                                            },
+                                            {
+                                                "required": [
+                                                    "id",
+                                                    "users_number",
+                                                    "name"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                },
+                                "examples": {
+                                    "Departments": {
+                                        "value": [
+                                            {
+                                                "name": "HR department",
+                                                "users_number": 5,
+                                                "selected_users_number": 0,
+                                                "id": 7
+                                            },
+                                            {
+                                                "name": "Accounts department",
+                                                "users_number": 4,
+                                                "selected_users_number": 1,
+                                                "id": 3
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                        "description": "Departments list response"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "listDepartments",
+                "description": "Returns a list of company departments with the number of employees"
+            }
+        },
+        "/users/{user_id}/passports": {
+            "get": {
+                "parameters": [
+                    {
+                        "name": "user_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "allOf": [
+                                            {
+                                                "$ref": "#/components/schemas/Passport"
+                                            },
+                                            {
+                                                "required": [
+                                                    "id",
+                                                    "number",
+                                                    "issued_date",
+                                                    "issued_by",
+                                                    "type",
+                                                    "has_scan"
+                                                ]
+                                            },
+                                            {
+                                                "type": "object",
+                                                "properties": {
+                                                    "visas_count": {
+                                                        "description": "",
+                                                        "type": "integer"
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                        "description": "List employee passports"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "404": {
+                        "description": "Employee not found response"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "listPassports",
+                "description": "Returns list of employee's passport"
+            },
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/Passport"
+                                    },
+                                    {
+                                        "required": [
+                                            "number",
+                                            "issued_date",
+                                            "issued_by",
+                                            "type"
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "parameters": [
+                    {
+                        "name": "user_id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "headers": {
+                            "Location": {
+                                "schema": {
+                                    "format": "uri",
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Passport added response, \nLocation header returns a new employee passport URL"
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "409": {
+                        "description": "Add passport conflict response: the passport already exists"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "addPassport",
+                "description": "Creates a new employee's passport"
+            }
+        },
         "/users/{user_id}": {
             "get": {
                 "responses": {
@@ -1950,22 +2021,14 @@
                     }
                 ],
                 "operationId": "getUser",
-                "description": "Returns the employee based on ID"
+                "description": "Returns the employee full data based on ID"
             },
             "patch": {
                 "requestBody": {
                     "content": {
                         "application/json": {
                             "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/FullUser"
-                                    },
-                                    {
-                                        "minProperties": 1,
-                                        "type": "object"
-                                    }
-                                ]
+                                "$ref": "#/components/schemas/PatchFullUser"
                             },
                             "examples": {
                                 "Path example": {
@@ -2015,84 +2078,6 @@
                     "required": true
                 }
             ]
-        },
-        "/users/{user_id}/scans/{scan_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "allOf": [
-                                        {
-                                            "$ref": "#/components/schemas/Scan"
-                                        },
-                                        {
-                                            "required": [
-                                                "id",
-                                                "type",
-                                                "upload_at"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            }
-                        },
-                        "description": "Employee document scan response"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/UnauthorizedError"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": []
-                    }
-                ],
-                "operationId": "getScan",
-                "description": "Returns the employee's document scan based on ID"
-            },
-            "delete": {
-                "responses": {
-                    "200": {
-                        "description": "Employee scan deleted response (empty)"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/UnauthorizedError"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": []
-                    }
-                ],
-                "operationId": "deleteScan",
-                "description": "Deletes the employee's document scan based on ID"
-            },
-            "parameters": [
-                {
-                    "name": "user_id",
-                    "schema": {
-                        "type": "integer"
-                    },
-                    "in": "path",
-                    "required": true
-                },
-                {
-                    "name": "scan_id",
-                    "schema": {
-                        "type": "integer"
-                    },
-                    "in": "path",
-                    "required": true
-                }
-            ]
         }
     },
     "components": {
@@ -2107,34 +2092,6 @@
                 "example": {
                     "mobile": 79999999999,
                     "office": 123456
-                }
-            },
-            "Department": {
-                "description": "",
-                "required": [
-                    "id",
-                    "name"
-                ],
-                "type": "object",
-                "properties": {
-                    "name": {
-                        "description": "",
-                        "maxLength": 150,
-                        "minLength": 2,
-                        "type": "string"
-                    },
-                    "users_number": {
-                        "description": "current number of working employees",
-                        "type": "integer"
-                    },
-                    "id": {
-                        "description": "",
-                        "type": "integer"
-                    },
-                    "recruited_users_number": {
-                        "description": "number of recruited employees",
-                        "type": "integer"
-                    }
                 }
             },
             "ScanType": {
@@ -2155,135 +2112,6 @@
                     "other"
                 ],
                 "type": "string"
-            },
-            "Military": {
-                "description": "",
-                "required": [
-                    "speciality",
-                    "rank",
-                    "comissariat",
-                    "category",
-                    "has_scan"
-                ],
-                "type": "object",
-                "properties": {
-                    "rank": {
-                        "description": "",
-                        "maxLength": 150,
-                        "type": "string"
-                    },
-                    "speciality": {
-                        "description": "",
-                        "maxLength": 7,
-                        "minLength": 6,
-                        "type": "string"
-                    },
-                    "category": {
-                        "description": "",
-                        "maxLength": 2,
-                        "minLength": 1,
-                        "type": "string"
-                    },
-                    "comissariat": {
-                        "description": "",
-                        "maxLength": 150,
-                        "type": "string"
-                    },
-                    "has_scan": {
-                        "description": "",
-                        "type": "boolean",
-                        "readOnly": true
-                    }
-                },
-                "example": {
-                    "rank": "Старший лейтенант",
-                    "speciality": "101182",
-                    "category": "А2",
-                    "comissariat": "Военный комиссариат Петроградского района г. Санкт-Петербурга",
-                    "has_scan": true
-                }
-            },
-            "Taxpayer": {
-                "description": "",
-                "required": [
-                    "has_scan",
-                    "number"
-                ],
-                "type": "object",
-                "properties": {
-                    "number": {
-                        "description": "",
-                        "maxLength": 12,
-                        "minLength": 10,
-                        "type": "string",
-                        "example": ""
-                    },
-                    "has_scan": {
-                        "description": "",
-                        "type": "boolean",
-                        "readOnly": true
-                    }
-                },
-                "example": {
-                    "number": "500100732259",
-                    "has_scan": true
-                }
-            },
-            "Insurance": {
-                "description": "",
-                "type": "object",
-                "properties": {
-                    "number": {
-                        "description": "",
-                        "maxLength": 11,
-                        "minLength": 11,
-                        "type": "string"
-                    },
-                    "has_scan": {
-                        "description": "",
-                        "type": "boolean",
-                        "readOnly": true
-                    }
-                },
-                "example": {
-                    "number": "08336732477",
-                    "has_scan": true
-                }
-            },
-            "WorkPermit": {
-                "description": "",
-                "required": [
-                    "has_scan",
-                    "number",
-                    "valid_to"
-                ],
-                "type": "object",
-                "properties": {
-                    "number": {
-                        "description": "",
-                        "type": "string"
-                    },
-                    "valid_to": {
-                        "format": "date",
-                        "description": "",
-                        "type": "string"
-                    },
-                    "valid_from": {
-                        "format": "date",
-                        "description": "",
-                        "type": "string"
-                    },
-                    "has_scan": {
-                        "description": "",
-                        "type": "boolean",
-                        "readOnly": true
-                    }
-                },
-                "example": {
-                    "number": "77121034092",
-                    "valid_to": "2013-09-05",
-                    "has_scan": true
-                }
             },
             "Error": {
                 "required": [
@@ -2648,7 +2476,258 @@
                     }
                 }
             },
+            "Military": {
+                "description": "",
+                "type": "object",
+                "properties": {
+                    "rank": {
+                        "description": "",
+                        "maxLength": 150,
+                        "type": "string"
+                    },
+                    "speciality": {
+                        "description": "",
+                        "maxLength": 7,
+                        "minLength": 6,
+                        "type": "string"
+                    },
+                    "category": {
+                        "description": "",
+                        "maxLength": 2,
+                        "minLength": 1,
+                        "type": "string"
+                    },
+                    "comissariat": {
+                        "description": "",
+                        "maxLength": 150,
+                        "type": "string"
+                    },
+                    "has_scan": {
+                        "description": "",
+                        "type": "boolean",
+                        "readOnly": true
+                    }
+                },
+                "example": {
+                    "rank": "Старший лейтенант",
+                    "speciality": "101182",
+                    "category": "А2",
+                    "comissariat": "Военный комиссариат Петроградского района г. Санкт-Петербурга",
+                    "has_scan": true
+                }
+            },
+            "WorkPermit": {
+                "description": "",
+                "type": "object",
+                "properties": {
+                    "number": {
+                        "description": "",
+                        "type": "string"
+                    },
+                    "valid_to": {
+                        "format": "date",
+                        "description": "",
+                        "type": "string"
+                    },
+                    "valid_from": {
+                        "format": "date",
+                        "description": "",
+                        "type": "string"
+                    },
+                    "has_scan": {
+                        "description": "",
+                        "type": "boolean",
+                        "readOnly": true
+                    }
+                },
+                "example": {
+                    "number": "77121034092",
+                    "valid_to": "2013-09-05",
+                    "has_scan": true
+                }
+            },
+            "Taxpayer": {
+                "description": "",
+                "type": "object",
+                "properties": {
+                    "number": {
+                        "description": "",
+                        "maxLength": 12,
+                        "minLength": 10,
+                        "type": "string",
+                        "example": ""
+                    },
+                    "has_scan": {
+                        "description": "",
+                        "type": "boolean",
+                        "readOnly": true
+                    }
+                },
+                "example": {
+                    "number": "500100732259",
+                    "has_scan": true
+                }
+            },
             "FullUser": {
+                "required": [],
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/ShortUser"
+                    },
+                    {
+                        "properties": {
+                            "grade": {
+                                "description": "",
+                                "maxLength": 1,
+                                "minLength": 1,
+                                "type": "string"
+                            },
+                            "date_of_birth": {
+                                "format": "date",
+                                "description": "",
+                                "type": "string"
+                            },
+                            "place_of_birth": {
+                                "description": "",
+                                "maxLength": 150,
+                                "minLength": 2,
+                                "type": "string"
+                            },
+                            "registration_address": {
+                                "description": "",
+                                "maxLength": 150,
+                                "minLength": 2,
+                                "type": "string"
+                            },
+                            "residential_address": {
+                                "description": "",
+                                "maxLength": 150,
+                                "minLength": 2,
+                                "type": "string"
+                            },
+                            "nationality": {
+                                "description": "",
+                                "maxLength": 150,
+                                "minLength": 2,
+                                "type": "string"
+                            },
+                            "foreign_languages": {
+                                "description": "",
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "military": {
+                                "description": "",
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/Military"
+                                    },
+                                    {
+                                        "required": [
+                                            "speciality",
+                                            "rank",
+                                            "comissariat",
+                                            "category"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "taxpayer": {
+                                "description": "",
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/Taxpayer"
+                                    },
+                                    {
+                                        "required": [
+                                            "number"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "insurance": {
+                                "description": "",
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/Insurance"
+                                    },
+                                    {
+                                        "required": [
+                                            "number"
+                                        ]
+                                    }
+                                ]
+                            },
+                            "work_permit": {
+                                "description": "",
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/WorkPermit"
+                                    },
+                                    {
+                                        "required": [
+                                            "number",
+                                            "valid_to"
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                ],
+                "example": {
+                    "grade": "1",
+                    "date_of_birth": "2018-01-17",
+                    "place_of_birth": "Москва",
+                    "registration_address": "Санкт-Петербург, наб. реки Мойки, 12",
+                    "residential_address": "Санкт-Петербург, наб. реки Мойки, 12",
+                    "nationality": "Царская Россия",
+                    "foreign_languages": [
+                        "english",
+                        "french"
+                    ],
+                    "military": {
+                        "rank": "Старший лейтенант",
+                        "speciality": "101182",
+                        "category": "А2",
+                        "comissariat": "Военный комиссариат Петроградского района г. Санкт-Петербурга",
+                        "has_scan": true
+                    },
+                    "taxpayer": {
+                        "number": "500100732259",
+                        "has_scan": true
+                    },
+                    "insurance": {
+                        "number": "08336732477",
+                        "has_scan": true
+                    }
+                }
+            },
+            "Insurance": {
+                "description": "",
+                "type": "object",
+                "properties": {
+                    "number": {
+                        "description": "",
+                        "maxLength": 11,
+                        "minLength": 11,
+                        "type": "string"
+                    },
+                    "has_scan": {
+                        "description": "",
+                        "type": "boolean",
+                        "readOnly": true
+                    }
+                },
+                "example": {
+                    "number": "08336732477",
+                    "has_scan": true
+                }
+            },
+            "PatchFullUser": {
+                "minProperties": 1,
                 "required": [],
                 "allOf": [
                     {
@@ -2704,15 +2783,10 @@
                             },
                             "taxpayer": {
                                 "$ref": "#/components/schemas/Taxpayer",
-                                "description": "",
-                                "maxLength": 12,
-                                "minLength": 10
+                                "description": ""
                             },
                             "insurance": {
-                                "$ref": "#/components/schemas/Insurance",
-                                "description": "",
-                                "maxLength": 11,
-                                "minLength": 11
+                                "$ref": "#/components/schemas/Insurance"
                             },
                             "work_permit": {
                                 "$ref": "#/components/schemas/WorkPermit",
@@ -2720,32 +2794,30 @@
                             }
                         }
                     }
-                ],
-                "example": {
-                    "grade": "1",
-                    "date_of_birth": "2018-01-17",
-                    "place_of_birth": "Москва",
-                    "registration_address": "Санкт-Петербург, наб. реки Мойки, 12",
-                    "residential_address": "Санкт-Петербург, наб. реки Мойки, 12",
-                    "nationality": "Царская Россия",
-                    "foreign_languages": [
-                        "english",
-                        "french"
-                    ],
-                    "military": {
-                        "rank": "Старший лейтенант",
-                        "speciality": "101182",
-                        "category": "А2",
-                        "comissariat": "Военный комиссариат Петроградского района г. Санкт-Петербурга",
-                        "has_scan": true
+                ]
+            },
+            "Department": {
+                "description": "",
+                "required": [],
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "description": "",
+                        "maxLength": 150,
+                        "minLength": 2,
+                        "type": "string"
                     },
-                    "taxpayer": {
-                        "number": "500100732259",
-                        "has_scan": true
+                    "users_number": {
+                        "description": "current number of working employees",
+                        "type": "integer"
                     },
-                    "insurance": {
-                        "number": "08336732477",
-                        "has_scan": true
+                    "id": {
+                        "description": "",
+                        "type": "integer"
+                    },
+                    "recruited_users_number": {
+                        "description": "number of recruited employees",
+                        "type": "integer"
                     }
                 }
             }

--- a/api/api.json
+++ b/api/api.json
@@ -2,7 +2,7 @@
     "openapi": "3.0.2",
     "info": {
         "title": "Employee's cabinet",
-        "version": "0.7.1",
+        "version": "0.7.2",
         "description": "",
         "contact": {
             "name": "Yandex Practicum Students Team"
@@ -2524,105 +2524,6 @@
                     ]
                 }
             },
-            "FullUser": {
-                "required": [],
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/ShortUser"
-                    }
-                ],
-                "properties": {
-                    "grade": {
-                        "description": "",
-                        "maxLength": 1,
-                        "minLength": 1,
-                        "type": "string"
-                    },
-                    "date_of_birth": {
-                        "format": "date",
-                        "description": "",
-                        "type": "string"
-                    },
-                    "place_of_birth": {
-                        "description": "",
-                        "maxLength": 150,
-                        "minLength": 2,
-                        "type": "string"
-                    },
-                    "registration_address": {
-                        "description": "",
-                        "maxLength": 150,
-                        "minLength": 2,
-                        "type": "string"
-                    },
-                    "residential_address": {
-                        "description": "",
-                        "maxLength": 150,
-                        "minLength": 2,
-                        "type": "string"
-                    },
-                    "nationality": {
-                        "description": "",
-                        "maxLength": 150,
-                        "minLength": 2,
-                        "type": "string"
-                    },
-                    "foreign_languages": {
-                        "description": "",
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "military": {
-                        "$ref": "#/components/schemas/Military",
-                        "description": ""
-                    },
-                    "taxpayer": {
-                        "$ref": "#/components/schemas/Taxpayer",
-                        "description": "",
-                        "maxLength": 12,
-                        "minLength": 10
-                    },
-                    "insurance": {
-                        "$ref": "#/components/schemas/Insurance",
-                        "description": "",
-                        "maxLength": 11,
-                        "minLength": 11
-                    },
-                    "work_permit": {
-                        "$ref": "#/components/schemas/WorkPermit",
-                        "description": ""
-                    }
-                },
-                "example": {
-                    "grade": "1",
-                    "date_of_birth": "2018-01-17",
-                    "place_of_birth": "Москва",
-                    "registration_address": "Санкт-Петербург, наб. реки Мойки, 12",
-                    "residential_address": "Санкт-Петербург, наб. реки Мойки, 12",
-                    "nationality": "Царская Россия",
-                    "foreign_languages": [
-                        "english",
-                        "french"
-                    ],
-                    "military": {
-                        "rank": "Старший лейтенант",
-                        "speciality": "101182",
-                        "category": "А2",
-                        "comissariat": "Военный комиссариат Петроградского района г. Санкт-Петербурга",
-                        "has_scan": true
-                    },
-                    "taxpayer": {
-                        "number": "500100732259",
-                        "has_scan": true
-                    },
-                    "insurance": {
-                        "number": "08336732477",
-                        "has_scan": true
-                    }
-                }
-            },
             "Vacation": {
                 "description": "",
                 "required": [],
@@ -2744,6 +2645,107 @@
                         "minLength": 8,
                         "type": "string",
                         "example": "pa$$word"
+                    }
+                }
+            },
+            "FullUser": {
+                "required": [],
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/ShortUser"
+                    },
+                    {
+                        "properties": {
+                            "grade": {
+                                "description": "",
+                                "maxLength": 1,
+                                "minLength": 1,
+                                "type": "string"
+                            },
+                            "date_of_birth": {
+                                "format": "date",
+                                "description": "",
+                                "type": "string"
+                            },
+                            "place_of_birth": {
+                                "description": "",
+                                "maxLength": 150,
+                                "minLength": 2,
+                                "type": "string"
+                            },
+                            "registration_address": {
+                                "description": "",
+                                "maxLength": 150,
+                                "minLength": 2,
+                                "type": "string"
+                            },
+                            "residential_address": {
+                                "description": "",
+                                "maxLength": 150,
+                                "minLength": 2,
+                                "type": "string"
+                            },
+                            "nationality": {
+                                "description": "",
+                                "maxLength": 150,
+                                "minLength": 2,
+                                "type": "string"
+                            },
+                            "foreign_languages": {
+                                "description": "",
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "military": {
+                                "$ref": "#/components/schemas/Military",
+                                "description": ""
+                            },
+                            "taxpayer": {
+                                "$ref": "#/components/schemas/Taxpayer",
+                                "description": "",
+                                "maxLength": 12,
+                                "minLength": 10
+                            },
+                            "insurance": {
+                                "$ref": "#/components/schemas/Insurance",
+                                "description": "",
+                                "maxLength": 11,
+                                "minLength": 11
+                            },
+                            "work_permit": {
+                                "$ref": "#/components/schemas/WorkPermit",
+                                "description": ""
+                            }
+                        }
+                    }
+                ],
+                "example": {
+                    "grade": "1",
+                    "date_of_birth": "2018-01-17",
+                    "place_of_birth": "Москва",
+                    "registration_address": "Санкт-Петербург, наб. реки Мойки, 12",
+                    "residential_address": "Санкт-Петербург, наб. реки Мойки, 12",
+                    "nationality": "Царская Россия",
+                    "foreign_languages": [
+                        "english",
+                        "french"
+                    ],
+                    "military": {
+                        "rank": "Старший лейтенант",
+                        "speciality": "101182",
+                        "category": "А2",
+                        "comissariat": "Военный комиссариат Петроградского района г. Санкт-Петербурга",
+                        "has_scan": true
+                    },
+                    "taxpayer": {
+                        "number": "500100732259",
+                        "has_scan": true
+                    },
+                    "insurance": {
+                        "number": "08336732477",
+                        "has_scan": true
                     }
                 }
             }

--- a/api/api.json
+++ b/api/api.json
@@ -2,7 +2,7 @@
     "openapi": "3.0.2",
     "info": {
         "title": "Employee's cabinet",
-        "version": "0.9.0",
+        "version": "0.10.0",
         "description": "",
         "contact": {
             "name": "Yandex Practicum Students Team"
@@ -1521,334 +1521,6 @@
                 "description": "Creates a new employee's passport"
             }
         },
-        "/users/{user_id}": {
-            "get": {
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "allOf": [
-                                        {
-                                            "$ref": "#/components/schemas/FullUser"
-                                        },
-                                        {
-                                            "required": [
-                                                "id",
-                                                "first_name",
-                                                "last_name",
-                                                "date_of_birth"
-                                            ]
-                                        },
-                                        {
-                                            "type": "object",
-                                            "properties": {
-                                                "id": {
-                                                    "description": "",
-                                                    "type": "integer"
-                                                },
-                                                "passports": {
-                                                    "description": "",
-                                                    "type": "array",
-                                                    "items": {
-                                                        "allOf": [
-                                                            {
-                                                                "$ref": "#/components/schemas/Passport"
-                                                            },
-                                                            {
-                                                                "required": [
-                                                                    "id",
-                                                                    "number",
-                                                                    "issued_date",
-                                                                    "issued_by",
-                                                                    "type",
-                                                                    "has_scan"
-                                                                ]
-                                                            },
-                                                            {
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "visas": {
-                                                                        "description": "",
-                                                                        "type": "array",
-                                                                        "items": {
-                                                                            "allOf": [
-                                                                                {
-                                                                                    "$ref": "#/components/schemas/Visa"
-                                                                                },
-                                                                                {
-                                                                                    "required": [
-                                                                                        "id",
-                                                                                        "has_scan",
-                                                                                        "number",
-                                                                                        "issued_state",
-                                                                                        "valid_to",
-                                                                                        "valid_from",
-                                                                                        "number_entries"
-                                                                                    ]
-                                                                                }
-                                                                            ]
-                                                                        }
-                                                                    }
-                                                                }
-                                                            }
-                                                        ]
-                                                    }
-                                                },
-                                                "contracts": {
-                                                    "description": "",
-                                                    "type": "array",
-                                                    "items": {
-                                                        "allOf": [
-                                                            {
-                                                                "$ref": "#/components/schemas/Contract"
-                                                            },
-                                                            {
-                                                                "required": [
-                                                                    "id",
-                                                                    "has_scan",
-                                                                    "date_from",
-                                                                    "type",
-                                                                    "number"
-                                                                ]
-                                                            }
-                                                        ]
-                                                    }
-                                                },
-                                                "vacations": {
-                                                    "description": "",
-                                                    "type": "array",
-                                                    "items": {
-                                                        "allOf": [
-                                                            {
-                                                                "$ref": "#/components/schemas/Vacation"
-                                                            },
-                                                            {
-                                                                "required": [
-                                                                    "id",
-                                                                    "date_from",
-                                                                    "date_to"
-                                                                ]
-                                                            }
-                                                        ]
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    ]
-                                },
-                                "examples": {
-                                    "Employee example": {
-                                        "value": {
-                                            "id": 5,
-                                            "first_name": "Alexander",
-                                            "last_name": "Pushkin",
-                                            "middle_name": "Sergeyevich",
-                                            "position": "Novelist",
-                                            "department": "Collegium of Foreign Affairs",
-                                            "email": "pushkin@dantes.net",
-                                            "phone_numbers": [
-                                                {
-                                                    "number": "799183712345",
-                                                    "type": "mobile"
-                                                },
-                                                {
-                                                    "number": "1837",
-                                                    "type": "office"
-                                                }
-                                            ],
-                                            "passports": [
-                                                {
-                                                    "id": 5,
-                                                    "visas": [
-                                                        {
-                                                            "id": 9,
-                                                            "number": "33592222",
-                                                            "issued_state": "Germany",
-                                                            "valid_to": "1820-10-22",
-                                                            "valid_from": "1820-09-08",
-                                                            "number_entries": "2",
-                                                            "has_scan": false
-                                                        }
-                                                    ],
-                                                    "number": "4011364219",
-                                                    "issued_date": "1817-05-15",
-                                                    "issued_by": "ТП № 28 отдела УФМС России по СПб и ЛО",
-                                                    "type": "internal",
-                                                    "has_scan": false
-                                                }
-                                            ],
-                                            "contracts": [
-                                                {
-                                                    "date_from": "1819-01-17",
-                                                    "date_to": "1821-01-17",
-                                                    "type": "temporary",
-                                                    "number": "1000005"
-                                                }
-                                            ],
-                                            "grade": "1",
-                                            "date_of_birth": "1799-05-26",
-                                            "place_of_birth": "Москва",
-                                            "registration_address": "Санкт-Петербург, наб. реки Мойки, 12",
-                                            "residential_address": "Санкт-Петербург, наб. реки Мойки, 12",
-                                            "nationality": "Царская Россия",
-                                            "foreign_languages": [
-                                                "english",
-                                                "french"
-                                            ],
-                                            "military": {
-                                                "rank": "Старший лейтенант",
-                                                "speciality": "101182",
-                                                "category": "А2",
-                                                "comissariat": "Военный комиссариат Петроградского района г. Санкт-Петербурга",
-                                                "has_scan": true
-                                            },
-                                            "vacations": [
-                                                {
-                                                    "id": 78,
-                                                    "date_from": "1820-03-11",
-                                                    "date_to": "1820-03-25"
-                                                }
-                                            ],
-                                            "taxpayer": {
-                                                "number": "500100732259",
-                                                "has_scan": true
-                                            },
-                                            "insurance": {
-                                                "number": "08336732477",
-                                                "has_scan": true
-                                            }
-                                        }
-                                    },
-                                    "Foreigner example": {
-                                        "value": {
-                                            "id": 93,
-                                            "first_name": "Улугбек",
-                                            "last_name": "Акрамов",
-                                            "middle_name": "Рашидович",
-                                            "position": "Строитель",
-                                            "department": "Инженерный отдел",
-                                            "email": "akramovur@rogakopyta.net",
-                                            "phone_numbers": [
-                                                {
-                                                    "number": "799183712345",
-                                                    "type": "mobile"
-                                                },
-                                                {
-                                                    "number": "1837",
-                                                    "type": "office"
-                                                }
-                                            ],
-                                            "passports": [
-                                                {
-                                                    "id": 67,
-                                                    "number": "AZ0001055",
-                                                    "issued_date": "2010-05-23",
-                                                    "issued_by": "TOSHKENT SHAHAR IIBB",
-                                                    "type": "foreigners",
-                                                    "has_scan": true
-                                                }
-                                            ],
-                                            "contracts": [
-                                                {
-                                                    "date_from": "2013-08-01",
-                                                    "date_to": "2013-09-04",
-                                                    "type": "temporary",
-                                                    "number": "12345"
-                                                }
-                                            ],
-                                            "work_permit": {
-                                                "number": "77121034092",
-                                                "valid_to": "2013-09-05",
-                                                "has_scan": true
-                                            },
-                                            "grade": "2",
-                                            "date_of_birth": "1994-05-26",
-                                            "place_of_birth": "Ташкент",
-                                            "registration_address": "Санкт-Петербург, наб. реки Мойки, 27",
-                                            "residential_address": "Санкт-Петербург, наб. реки Мойки, 27",
-                                            "nationality": "Узбекистан"
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "description": "Employee response"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/UnauthorizedError"
-                    },
-                    "404": {
-                        "description": "Employee not found response"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": []
-                    }
-                ],
-                "operationId": "getUser",
-                "description": "Returns the employee full data based on ID"
-            },
-            "patch": {
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/PatchFullUser"
-                            },
-                            "examples": {
-                                "Path example": {
-                                    "value": {
-                                        "grade": "2",
-                                        "registration_address": "Moscow, Tverskaya street, building 32, apartment 17"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Employee updated response (empty)"
-                    },
-                    "400": {
-                        "$ref": "#/components/responses/BadRequest"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/UnauthorizedError"
-                    },
-                    "404": {
-                        "description": "Employee not found"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": []
-                    }
-                ],
-                "operationId": "patchUser",
-                "description": "Changes selected fields in the user structure based on ID"
-            },
-            "parameters": [
-                {
-                    "name": "user_id",
-                    "description": "employee ID",
-                    "schema": {
-                        "type": "integer"
-                    },
-                    "in": "path",
-                    "required": true
-                }
-            ]
-        },
         "/users": {
             "get": {
                 "parameters": [
@@ -2079,6 +1751,899 @@
                 "operationId": "addUser",
                 "description": "Creates a new employe in the company"
             }
+        },
+        "/users/{user_id}/educations": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "allOf": [
+                                            {
+                                                "$ref": "#/components/schemas/Education"
+                                            },
+                                            {
+                                                "required": [
+                                                    "id",
+                                                    "has_scan",
+                                                    "date_from",
+                                                    "issued_institution"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                        "description": "Employee education list response"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "listEducations",
+                "description": "Returns list of employee's educations"
+            },
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/Education"
+                                    },
+                                    {
+                                        "required": [
+                                            "date_from",
+                                            "issued_institution"
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "headers": {
+                            "Location": {
+                                "schema": {
+                                    "format": "uri",
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Employee education added response,\nLocation header returns a new employee education URL"
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "409": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "description": "Add education conflict response: the education already exists"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "addEducation",
+                "description": "Creates a new employee education"
+            },
+            "parameters": [
+                {
+                    "name": "user_id",
+                    "schema": {
+                        "type": "integer"
+                    },
+                    "in": "path",
+                    "required": true
+                }
+            ]
+        },
+        "/users/{user_id}/educations/{education_id}": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/Education"
+                                        },
+                                        {
+                                            "required": [
+                                                "id",
+                                                "has_scan",
+                                                "date_from",
+                                                "issued_institution"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        "description": "Employee education response"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "404": {
+                        "description": "Employee/education not found response"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "getEducation",
+                "description": "Returns the employee education based on ID"
+            },
+            "delete": {
+                "responses": {
+                    "200": {
+                        "description": "Employee education deleted response (empty)"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "deleteEducation",
+                "description": "Deletes the employee education based on ID"
+            },
+            "patch": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/Education"
+                                    },
+                                    {
+                                        "minProperties": 1
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Employee education updated response (empty)"
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "patchEducation",
+                "description": "Changes selected fields in the employee education structure based on ID"
+            },
+            "parameters": [
+                {
+                    "name": "user_id",
+                    "schema": {
+                        "type": "integer"
+                    },
+                    "in": "path",
+                    "required": true
+                },
+                {
+                    "name": "education_id",
+                    "schema": {
+                        "type": "integer"
+                    },
+                    "in": "path",
+                    "required": true
+                }
+            ]
+        },
+        "/users/{user_id}/trainings": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "allOf": [
+                                            {
+                                                "$ref": "#/components/schemas/Training"
+                                            },
+                                            {
+                                                "required": [
+                                                    "id",
+                                                    "has_scan",
+                                                    "date_from",
+                                                    "issued_institution",
+                                                    "program"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                        "description": "Employee training list response"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "listTrainings",
+                "description": "Returns list of employee trainings"
+            },
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/Training"
+                                    },
+                                    {
+                                        "required": [
+                                            "date_from",
+                                            "issued_institution",
+                                            "program"
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "headers": {
+                            "Location": {
+                                "schema": {
+                                    "format": "uri",
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Employee training added response,\nLocation header returns a new employee training URL"
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "409": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "description": "Add training conflict response: the training already exists"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "addTraining",
+                "description": "Creates a new employee training"
+            },
+            "parameters": [
+                {
+                    "name": "user_id",
+                    "schema": {
+                        "type": "integer"
+                    },
+                    "in": "path",
+                    "required": true
+                }
+            ]
+        },
+        "/users/{user_id}/trainings/{training_id}": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/Training"
+                                        },
+                                        {
+                                            "required": [
+                                                "id",
+                                                "has_scan",
+                                                "date_from",
+                                                "issued_institution",
+                                                "program"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        "description": "Employee training response"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "404": {
+                        "description": "Employee/training not found response"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "getTraining",
+                "description": "Returns the employee training based on ID"
+            },
+            "delete": {
+                "responses": {
+                    "200": {
+                        "description": "Employee training deleted response (empty)"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "deleteTraining",
+                "description": "Deletes the employee training based on ID"
+            },
+            "patch": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/Training"
+                                    },
+                                    {
+                                        "minProperties": 1
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Employee training updated response (empty)"
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "patchTraining",
+                "description": "Changes selected fields in the employee training structure based on ID"
+            },
+            "parameters": [
+                {
+                    "name": "user_id",
+                    "schema": {
+                        "type": "integer"
+                    },
+                    "in": "path",
+                    "required": true
+                },
+                {
+                    "name": "training_id",
+                    "schema": {
+                        "type": "integer"
+                    },
+                    "in": "path",
+                    "required": true
+                }
+            ]
+        },
+        "/users/{user_id}": {
+            "get": {
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/FullUser"
+                                        },
+                                        {
+                                            "required": [
+                                                "id",
+                                                "first_name",
+                                                "last_name",
+                                                "date_of_birth"
+                                            ]
+                                        },
+                                        {
+                                            "type": "object",
+                                            "properties": {
+                                                "id": {
+                                                    "description": "",
+                                                    "type": "integer"
+                                                },
+                                                "passports": {
+                                                    "description": "",
+                                                    "type": "array",
+                                                    "items": {
+                                                        "allOf": [
+                                                            {
+                                                                "$ref": "#/components/schemas/Passport"
+                                                            },
+                                                            {
+                                                                "required": [
+                                                                    "id",
+                                                                    "number",
+                                                                    "issued_date",
+                                                                    "issued_by",
+                                                                    "type",
+                                                                    "has_scan"
+                                                                ]
+                                                            },
+                                                            {
+                                                                "type": "object",
+                                                                "properties": {
+                                                                    "visas": {
+                                                                        "description": "",
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "allOf": [
+                                                                                {
+                                                                                    "$ref": "#/components/schemas/Visa"
+                                                                                },
+                                                                                {
+                                                                                    "required": [
+                                                                                        "id",
+                                                                                        "has_scan",
+                                                                                        "number",
+                                                                                        "issued_state",
+                                                                                        "valid_to",
+                                                                                        "valid_from",
+                                                                                        "number_entries"
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                "contracts": {
+                                                    "description": "",
+                                                    "type": "array",
+                                                    "items": {
+                                                        "allOf": [
+                                                            {
+                                                                "$ref": "#/components/schemas/Contract"
+                                                            },
+                                                            {
+                                                                "required": [
+                                                                    "id",
+                                                                    "has_scan",
+                                                                    "date_from",
+                                                                    "type",
+                                                                    "number"
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                "vacations": {
+                                                    "description": "",
+                                                    "type": "array",
+                                                    "items": {
+                                                        "allOf": [
+                                                            {
+                                                                "$ref": "#/components/schemas/Vacation"
+                                                            },
+                                                            {
+                                                                "required": [
+                                                                    "id",
+                                                                    "date_from",
+                                                                    "date_to"
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                "educations": {
+                                                    "description": "",
+                                                    "type": "array",
+                                                    "items": {
+                                                        "allOf": [
+                                                            {
+                                                                "$ref": "#/components/schemas/Education"
+                                                            },
+                                                            {
+                                                                "required": [
+                                                                    "id",
+                                                                    "date_from",
+                                                                    "issued_institution"
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                "trainings": {
+                                                    "description": "",
+                                                    "type": "array",
+                                                    "items": {
+                                                        "allOf": [
+                                                            {
+                                                                "$ref": "#/components/schemas/Training"
+                                                            },
+                                                            {
+                                                                "required": [
+                                                                    "id",
+                                                                    "date_from",
+                                                                    "issued_institution",
+                                                                    "program"
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                "examples": {
+                                    "Employee example": {
+                                        "value": {
+                                            "id": 5,
+                                            "first_name": "Alexander",
+                                            "last_name": "Pushkin",
+                                            "middle_name": "Sergeyevich",
+                                            "position": "Novelist",
+                                            "department": "Collegium of Foreign Affairs",
+                                            "email": "pushkin@dantes.net",
+                                            "phone_numbers": [
+                                                {
+                                                    "number": "799183712345",
+                                                    "type": "mobile"
+                                                },
+                                                {
+                                                    "number": "1837",
+                                                    "type": "office"
+                                                }
+                                            ],
+                                            "passports": [
+                                                {
+                                                    "id": 5,
+                                                    "visas": [
+                                                        {
+                                                            "id": 9,
+                                                            "number": "33592222",
+                                                            "issued_state": "Germany",
+                                                            "valid_to": "1820-10-22",
+                                                            "valid_from": "1820-09-08",
+                                                            "number_entries": "2",
+                                                            "has_scan": false
+                                                        }
+                                                    ],
+                                                    "number": "4011364219",
+                                                    "issued_date": "1817-05-15",
+                                                    "issued_by": "ТП № 28 отдела УФМС России по СПб и ЛО",
+                                                    "type": "internal",
+                                                    "has_scan": false
+                                                }
+                                            ],
+                                            "contracts": [
+                                                {
+                                                    "date_from": "1819-01-17",
+                                                    "date_to": "1821-01-17",
+                                                    "type": "temporary",
+                                                    "number": "1000005"
+                                                }
+                                            ],
+                                            "grade": "1",
+                                            "date_of_birth": "1799-05-26",
+                                            "place_of_birth": "Москва",
+                                            "registration_address": "Санкт-Петербург, наб. реки Мойки, 12",
+                                            "residential_address": "Санкт-Петербург, наб. реки Мойки, 12",
+                                            "nationality": "Царская Россия",
+                                            "foreign_languages": [
+                                                "english",
+                                                "french"
+                                            ],
+                                            "military": {
+                                                "rank": "Старший лейтенант",
+                                                "speciality": "101182",
+                                                "category": "А2",
+                                                "comissariat": "Военный комиссариат Петроградского района г. Санкт-Петербурга",
+                                                "has_scan": true
+                                            },
+                                            "vacations": [
+                                                {
+                                                    "id": 78,
+                                                    "date_from": "1820-03-11",
+                                                    "date_to": "1820-03-25"
+                                                }
+                                            ],
+                                            "taxpayer": {
+                                                "number": "500100732259",
+                                                "has_scan": true
+                                            },
+                                            "insurance": {
+                                                "number": "08336732477",
+                                                "has_scan": true
+                                            }
+                                        }
+                                    },
+                                    "Foreigner example": {
+                                        "value": {
+                                            "id": 93,
+                                            "first_name": "Улугбек",
+                                            "last_name": "Акрамов",
+                                            "middle_name": "Рашидович",
+                                            "position": "Строитель",
+                                            "department": "Инженерный отдел",
+                                            "email": "akramovur@rogakopyta.net",
+                                            "phone_numbers": [
+                                                {
+                                                    "number": "799183712345",
+                                                    "type": "mobile"
+                                                },
+                                                {
+                                                    "number": "1837",
+                                                    "type": "office"
+                                                }
+                                            ],
+                                            "passports": [
+                                                {
+                                                    "id": 67,
+                                                    "number": "AZ0001055",
+                                                    "issued_date": "2010-05-23",
+                                                    "issued_by": "TOSHKENT SHAHAR IIBB",
+                                                    "type": "foreigners",
+                                                    "has_scan": true
+                                                }
+                                            ],
+                                            "contracts": [
+                                                {
+                                                    "date_from": "2013-08-01",
+                                                    "date_to": "2013-09-04",
+                                                    "type": "temporary",
+                                                    "number": "12345"
+                                                }
+                                            ],
+                                            "work_permit": {
+                                                "number": "77121034092",
+                                                "valid_to": "2013-09-05",
+                                                "has_scan": true
+                                            },
+                                            "grade": "2",
+                                            "date_of_birth": "1994-05-26",
+                                            "place_of_birth": "Ташкент",
+                                            "registration_address": "Санкт-Петербург, наб. реки Мойки, 27",
+                                            "residential_address": "Санкт-Петербург, наб. реки Мойки, 27",
+                                            "nationality": "Узбекистан"
+                                        }
+                                    },
+                                    "Additional data example": {
+                                        "value": {
+                                            "id": 9,
+                                            "first_name": "Сергей",
+                                            "last_name": "Сказочкин",
+                                            "middle_name": "Дмитриевич",
+                                            "position": "На дуде игрец",
+                                            "department": "Отдел развития фантазии",
+                                            "email": "sergei@fairy.com",
+                                            "date_of_birth": "1978-07-23",
+                                            "position_track": [
+                                                {
+                                                    "date_from": "2018-01-17",
+                                                    "date_to": "2018-03-17",
+                                                    "position": "Швец"
+                                                },
+                                                {
+                                                    "date_from": "2018-03-18",
+                                                    "date_to": "2018-05-18",
+                                                    "position": "Жнец"
+                                                },
+                                                {
+                                                    "date_from": "2018-05-19",
+                                                    "position": "На дуде игрец"
+                                                }
+                                            ],
+                                            "educations": [
+                                                {
+                                                    "id": 578,
+                                                    "has_scan": true,
+                                                    "number": "1030180354933",
+                                                    "date_to": "2015-01-01",
+                                                    "date_from": "2011-01-01",
+                                                    "issued_institution": "ФГБОУ ВО «Астраханский государственный университет им. В. Н. Татищева»",
+                                                    "program": "Связи с общественностью"
+                                                }
+                                            ],
+                                            "trainings": [
+                                                {
+                                                    "number": "A15/456878-456",
+                                                    "issued_institution": "Yandex Practicum",
+                                                    "program": "Advanced Go developer",
+                                                    "cost": 120000,
+                                                    "date_to": "2023-01-10",
+                                                    "date_from": "2023-07-10",
+                                                    "id": 95,
+                                                    "has_scan": true
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": "Employee response"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "404": {
+                        "description": "Employee not found response"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "getUser",
+                "description": "Returns the employee full data based on ID"
+            },
+            "patch": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchFullUser"
+                            },
+                            "examples": {
+                                "Path example": {
+                                    "value": {
+                                        "grade": "2",
+                                        "registration_address": "Moscow, Tverskaya street, building 32, apartment 17"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Employee updated response (empty)"
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "404": {
+                        "description": "Employee not found"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "patchUser",
+                "description": "Changes selected fields in the user structure based on ID"
+            },
+            "parameters": [
+                {
+                    "name": "user_id",
+                    "description": "employee ID",
+                    "schema": {
+                        "type": "integer"
+                    },
+                    "in": "path",
+                    "required": true
+                }
+            ]
         }
     },
     "components": {
@@ -2615,6 +3180,114 @@
                     }
                 }
             },
+            "PersonalDataProcessing": {
+                "description": "",
+                "type": "object",
+                "properties": {
+                    "has_scan": {
+                        "description": "",
+                        "type": "boolean",
+                        "readOnly": true
+                    }
+                },
+                "example": {
+                    "has_scan": true
+                }
+            },
+            "Training": {
+                "description": "",
+                "required": [],
+                "type": "object",
+                "properties": {
+                    "number": {
+                        "description": "",
+                        "maxLength": 50,
+                        "minLength": 2,
+                        "type": "string"
+                    },
+                    "issued_institution": {
+                        "description": "",
+                        "maxLength": 150,
+                        "minLength": 2,
+                        "type": "string"
+                    },
+                    "program": {
+                        "description": "",
+                        "maxLength": 150,
+                        "minLength": 2,
+                        "type": "string"
+                    },
+                    "cost": {
+                        "description": "cost per person",
+                        "type": "integer"
+                    },
+                    "date_to": {
+                        "format": "date",
+                        "description": "end date of training",
+                        "type": "string"
+                    },
+                    "date_from": {
+                        "format": "date",
+                        "description": "start date of training",
+                        "type": "string"
+                    },
+                    "id": {
+                        "description": "",
+                        "type": "integer"
+                    },
+                    "has_scan": {
+                        "description": "",
+                        "type": "boolean",
+                        "readOnly": true
+                    }
+                },
+                "example": {
+                    "number": "A15/456878-456",
+                    "issued_institution": "Yandex Practicum",
+                    "program": "Advanced Go developer",
+                    "cost": 120000,
+                    "date_to": "2023-01-10",
+                    "date_from": "2023-07-10",
+                    "id": 95,
+                    "has_scan": true
+                }
+            },
+            "PositionTrack": {
+                "description": "",
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "date_from": {
+                            "format": "date",
+                            "type": "string"
+                        },
+                        "date_to": {
+                            "format": "date",
+                            "type": "string"
+                        },
+                        "position": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "example": [
+                    {
+                        "date_from": "2018-01-17",
+                        "date_to": "2018-03-17",
+                        "position": "Швец"
+                    },
+                    {
+                        "date_from": "2018-03-18",
+                        "date_to": "2018-05-18",
+                        "position": "Жнец"
+                    },
+                    {
+                        "date_from": "2018-05-19",
+                        "position": "На дуде игрец"
+                    }
+                ]
+            },
             "FullUser": {
                 "required": [],
                 "allOf": [
@@ -2672,6 +3345,20 @@
                                     "type": "string"
                                 }
                             },
+                            "position_track": {
+                                "description": "",
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/PositionTrack"
+                                    },
+                                    {
+                                        "required": [
+                                            "date_from",
+                                            "position"
+                                        ]
+                                    }
+                                ]
+                            },
                             "military": {
                                 "description": "",
                                 "allOf": [
@@ -2727,6 +3414,10 @@
                                         ]
                                     }
                                 ]
+                            },
+                            "personal_data_processing": {
+                                "$ref": "#/components/schemas/PersonalDataProcessing",
+                                "description": ""
                             }
                         }
                     }
@@ -2832,10 +3523,67 @@
                             "work_permit": {
                                 "$ref": "#/components/schemas/WorkPermit",
                                 "description": ""
+                            },
+                            "position_track": {
+                                "$ref": "#/components/schemas/PositionTrack",
+                                "description": ""
                             }
                         }
                     }
                 ]
+            },
+            "Education": {
+                "description": "",
+                "required": [],
+                "type": "object",
+                "properties": {
+                    "number": {
+                        "description": "",
+                        "maxLength": 50,
+                        "minLength": 2,
+                        "type": "string"
+                    },
+                    "issued_institution": {
+                        "description": "",
+                        "maxLength": 150,
+                        "minLength": 2,
+                        "type": "string"
+                    },
+                    "date_to": {
+                        "format": "date",
+                        "description": "date of graduation",
+                        "type": "string"
+                    },
+                    "date_from": {
+                        "format": "date",
+                        "description": "date of commencement of studies",
+                        "type": "string"
+                    },
+                    "id": {
+                        "description": "",
+                        "type": "integer"
+                    },
+                    "has_scan": {
+                        "description": "",
+                        "type": "boolean",
+                        "readOnly": true
+                    },
+                    "program": {
+                        "description": "",
+                        "maxLength": 150,
+                        "minLength": 2,
+                        "type": "string"
+                    }
+                },
+                "example": {
+                    "id": 578,
+                    "has_scan": true,
+                    "number": "1030180354933",
+                    "date_to": "2015-01-01",
+                    "date_from": "2011-01-01",
+                    "issued_institution": "ФГБОУ ВО «Астраханский государственный университет им. В. Н. Татищева»",
+                    "program": "Связи с общественностью"
+                }
             }
         },
         "responses": {

--- a/api/api.json
+++ b/api/api.json
@@ -2,7 +2,7 @@
     "openapi": "3.0.2",
     "info": {
         "title": "Employee's cabinet",
-        "version": "0.10.0",
+        "version": "0.11.0",
         "description": "",
         "contact": {
             "name": "Yandex Practicum Students Team"
@@ -1172,82 +1172,6 @@
                 "description": "Authenticates a user and returns a paseto bearer token on success"
             }
         },
-        "/login/change-password": {
-            "get": {
-                "parameters": [
-                    {
-                        "examples": {
-                            "Key": {
-                                "value": "\"0LzQsNC80LAg0LzRi9C70LAg0YDQsNC80YM=\""
-                            }
-                        },
-                        "name": "key",
-                        "description": "a special key sent to the employee’s email",
-                        "schema": {
-                            "format": "byte",
-                            "type": "string"
-                        },
-                        "in": "query",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Check a change password key response (empty)"
-                    },
-                    "400": {
-                        "$ref": "#/components/responses/BadRequest"
-                    },
-                    "429": {
-                        "description": "Too many request response"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "operationId": "checkKey",
-                "description": "Checks a password change key that was sent to the user's email"
-            },
-            "post": {
-                "requestBody": {
-                    "description": "One of the request types: only login to get recovery key on email or key & a new password to change password",
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "oneOf": [
-                                    {
-                                        "$ref": "#/components/schemas/NewPassword"
-                                    },
-                                    {
-                                        "$ref": "#/components/schemas/Login"
-                                    }
-                                ]
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Change password response (empty)"
-                    },
-                    "400": {
-                        "$ref": "#/components/responses/BadRequest"
-                    },
-                    "404": {
-                        "description": "Employee not found"
-                    },
-                    "429": {
-                        "description": "Too many request response"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "operationId": "changePassword",
-                "description": "Accepts a login and sends the key to change the password to the user's email. \nOr it accepts the key and a new password and changes it."
-            }
-        },
         "/users/{user_id}/scans/{scan_id}": {
             "get": {
                 "responses": {
@@ -1519,237 +1443,6 @@
                 ],
                 "operationId": "addPassport",
                 "description": "Creates a new employee's passport"
-            }
-        },
-        "/users": {
-            "get": {
-                "parameters": [
-                    {
-                        "examples": {
-                            "Limit example": {
-                                "value": "50"
-                            }
-                        },
-                        "name": "limit",
-                        "description": "maximum number of results to return",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "query",
-                        "required": false
-                    },
-                    {
-                        "examples": {
-                            "Query": {
-                                "value": "\"Иванов\""
-                            }
-                        },
-                        "name": "query",
-                        "description": "query to find by",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "in": "query"
-                    },
-                    {
-                        "examples": {
-                            "Page example": {
-                                "value": "2"
-                            }
-                        },
-                        "name": "page",
-                        "description": "page number with results to return",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "query"
-                    },
-                    {
-                        "examples": {
-                            "SortByExample": {
-                                "value": "\"alphabet\""
-                            }
-                        },
-                        "name": "sort_by",
-                        "description": "type of sort result by",
-                        "schema": {
-                            "enum": [
-                                "alphabet",
-                                "department"
-                            ],
-                            "type": "string"
-                        },
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "allOf": [
-                                            {
-                                                "$ref": "#/components/schemas/ShortUser"
-                                            },
-                                            {
-                                                "required": [
-                                                    "id",
-                                                    "first_name",
-                                                    "last_name"
-                                                ],
-                                                "type": "object"
-                                            }
-                                        ]
-                                    }
-                                },
-                                "examples": {
-                                    "List employees example": {
-                                        "value": [
-                                            {
-                                                "first_name": "Alexander",
-                                                "last_name": "Pushkin",
-                                                "middle_name": "Sergeyevich",
-                                                "position": "Novelist",
-                                                "department": "Collegium of Foreign Affairs",
-                                                "email": "pushkin@dantes.net",
-                                                "phone_numbers": [
-                                                    {
-                                                        "number": "799183712345",
-                                                        "type": "mobile"
-                                                    },
-                                                    {
-                                                        "number": "1837",
-                                                        "type": "office"
-                                                    }
-                                                ]
-                                            },
-                                            {
-                                                "first_name": "Nikolai",
-                                                "last_name": "Gogol",
-                                                "middle_name": "Vasilievich",
-                                                "position": "Playwright",
-                                                "department": "Third Section of His Imperial Majesty's Own Chancellery",
-                                                "email": "gogol@fire.net",
-                                                "phone_numbers": [
-                                                    {
-                                                        "number": "799185212345",
-                                                        "type": "mobile"
-                                                    },
-                                                    {
-                                                        "number": "1821",
-                                                        "type": "office"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            }
-                        },
-                        "description": "Employees list response"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/UnauthorizedError"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": []
-                    }
-                ],
-                "operationId": "listUsers",
-                "description": "Returns list of company employees sorted alphabetically (default) or by department"
-            },
-            "post": {
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/FullUser"
-                                    },
-                                    {
-                                        "required": [
-                                            "first_name",
-                                            "last_name",
-                                            "date_of_birth"
-                                        ],
-                                        "type": "object"
-                                    }
-                                ]
-                            },
-                            "examples": {
-                                "Post employee example": {
-                                    "value": {
-                                        "first_name": "Alexander",
-                                        "last_name": "Pushkin",
-                                        "middle_name": "Sergeyevich",
-                                        "gender": "male",
-                                        "position": "Novelist",
-                                        "department": "Collegium of Foreign Affairs",
-                                        "email": "pushkin@dantes.net",
-                                        "phone_numbers": [
-                                            {
-                                                "number": "799183712345",
-                                                "type": "mobile"
-                                            },
-                                            {
-                                                "number": "1837",
-                                                "type": "office"
-                                            }
-                                        ],
-                                        "foreign_languages": [
-                                            "english",
-                                            "german"
-                                        ],
-                                        "military": {
-                                            "rank": "Старший лейтенант",
-                                            "speciality": "101182",
-                                            "category": "А2",
-                                            "comissariat": "Военный комиссариат Петроградского района г. Санкт-Петербурга"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "201": {
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "format": "uri",
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "description": "Employee created response, \nLocation header returns a new employee URL"
-                    },
-                    "400": {
-                        "$ref": "#/components/responses/BadRequest"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/UnauthorizedError"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": []
-                    }
-                ],
-                "operationId": "addUser",
-                "description": "Creates a new employe in the company"
             }
         },
         "/users/{user_id}/educations": {
@@ -2229,6 +1922,239 @@
                 }
             ]
         },
+        "/users": {
+            "get": {
+                "parameters": [
+                    {
+                        "examples": {
+                            "Limit example": {
+                                "value": "50"
+                            }
+                        },
+                        "name": "limit",
+                        "description": "maximum number of results to return",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "in": "query",
+                        "required": false
+                    },
+                    {
+                        "examples": {
+                            "Query": {
+                                "value": "\"Иванов\""
+                            }
+                        },
+                        "name": "query",
+                        "description": "query to find by",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "in": "query"
+                    },
+                    {
+                        "examples": {
+                            "Page example": {
+                                "value": "2"
+                            }
+                        },
+                        "name": "page",
+                        "description": "page number with results to return",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "in": "query"
+                    },
+                    {
+                        "examples": {
+                            "SortByExample": {
+                                "value": "\"alphabet\""
+                            }
+                        },
+                        "name": "sort_by",
+                        "description": "type of sort result by",
+                        "schema": {
+                            "default": "alphabet",
+                            "enum": [
+                                "alphabet",
+                                "department"
+                            ],
+                            "type": "string"
+                        },
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "allOf": [
+                                            {
+                                                "$ref": "#/components/schemas/ShortUser"
+                                            },
+                                            {
+                                                "required": [
+                                                    "id",
+                                                    "first_name",
+                                                    "last_name"
+                                                ],
+                                                "type": "object"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "examples": {
+                                    "List employees example": {
+                                        "value": [
+                                            {
+                                                "first_name": "Alexander",
+                                                "last_name": "Pushkin",
+                                                "middle_name": "Sergeyevich",
+                                                "position": "Novelist",
+                                                "department": "Collegium of Foreign Affairs",
+                                                "email": "pushkin@dantes.net",
+                                                "phone_numbers": [
+                                                    {
+                                                        "number": "799183712345",
+                                                        "type": "mobile"
+                                                    },
+                                                    {
+                                                        "number": "1837",
+                                                        "type": "office"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "first_name": "Nikolai",
+                                                "last_name": "Gogol",
+                                                "middle_name": "Vasilievich",
+                                                "position": "Playwright",
+                                                "department": "Third Section of His Imperial Majesty's Own Chancellery",
+                                                "email": "gogol@fire.net",
+                                                "phone_numbers": [
+                                                    {
+                                                        "number": "799185212345",
+                                                        "type": "mobile"
+                                                    },
+                                                    {
+                                                        "number": "1821",
+                                                        "type": "office"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                        "description": "Employees list response"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "listUsers",
+                "description": "Returns list of company employees sorted alphabetically (default) or by department"
+            },
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/FullUser"
+                                    },
+                                    {
+                                        "required": [
+                                            "first_name",
+                                            "last_name",
+                                            "date_of_birth",
+                                            "gender"
+                                        ],
+                                        "type": "object"
+                                    }
+                                ]
+                            },
+                            "examples": {
+                                "Post employee example": {
+                                    "value": {
+                                        "first_name": "Alexander",
+                                        "last_name": "Pushkin",
+                                        "middle_name": "Sergeyevich",
+                                        "gender": "male",
+                                        "position": "Novelist",
+                                        "department": "Collegium of Foreign Affairs",
+                                        "email": "pushkin@dantes.net",
+                                        "phone_numbers": [
+                                            {
+                                                "number": "799183712345",
+                                                "type": "mobile"
+                                            },
+                                            {
+                                                "number": "1837",
+                                                "type": "office"
+                                            }
+                                        ],
+                                        "foreign_languages": [
+                                            "english",
+                                            "german"
+                                        ],
+                                        "military": {
+                                            "rank": "Старший лейтенант",
+                                            "speciality": "101182",
+                                            "category": "А2",
+                                            "comissariat": "Военный комиссариат Петроградского района г. Санкт-Петербурга"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "headers": {
+                            "Location": {
+                                "schema": {
+                                    "format": "uri",
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Employee created response, \nLocation header returns a new employee URL"
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "addUser",
+                "description": "Creates a new employe in the company"
+            }
+        },
         "/users/{user_id}": {
             "get": {
                 "responses": {
@@ -2245,7 +2171,8 @@
                                                 "id",
                                                 "first_name",
                                                 "last_name",
-                                                "date_of_birth"
+                                                "date_of_birth",
+                                                "gender"
                                             ]
                                         },
                                         {
@@ -2432,6 +2359,7 @@
                                                 }
                                             ],
                                             "grade": "1",
+                                            "working_model": "remote",
                                             "date_of_birth": "1799-05-26",
                                             "place_of_birth": "Москва",
                                             "registration_address": "Санкт-Петербург, наб. реки Мойки, 12",
@@ -2462,7 +2390,8 @@
                                             "insurance": {
                                                 "number": "08336732477",
                                                 "has_scan": true
-                                            }
+                                            },
+                                            "gender": "male"
                                         }
                                     },
                                     "Foreigner example": {
@@ -2508,11 +2437,13 @@
                                                 "has_scan": true
                                             },
                                             "grade": "2",
+                                            "working_model": "in-office",
                                             "date_of_birth": "1994-05-26",
                                             "place_of_birth": "Ташкент",
                                             "registration_address": "Санкт-Петербург, наб. реки Мойки, 27",
                                             "residential_address": "Санкт-Петербург, наб. реки Мойки, 27",
-                                            "nationality": "Узбекистан"
+                                            "nationality": "Узбекистан",
+                                            "gender": "male"
                                         }
                                     },
                                     "Additional data example": {
@@ -2521,10 +2452,12 @@
                                             "first_name": "Сергей",
                                             "last_name": "Сказочкин",
                                             "middle_name": "Дмитриевич",
+                                            "gender": "male",
                                             "position": "На дуде игрец",
                                             "department": "Отдел развития фантазии",
                                             "email": "sergei@fairy.com",
                                             "date_of_birth": "1978-07-23",
+                                            "working_model": "hybrid",
                                             "position_track": [
                                                 {
                                                     "date_from": "2018-01-17",
@@ -2644,6 +2577,82 @@
                     "required": true
                 }
             ]
+        },
+        "/login/change-password": {
+            "get": {
+                "parameters": [
+                    {
+                        "examples": {
+                            "Key": {
+                                "value": "0LzQsNC80LAg0LzRi9C70LAg0YDQsNC80YM="
+                            }
+                        },
+                        "name": "key",
+                        "description": "a special key sent to the employee’s email",
+                        "schema": {
+                            "format": "byte",
+                            "type": "string"
+                        },
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Check a change password key response (empty)"
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest"
+                    },
+                    "429": {
+                        "description": "Too many request response"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "operationId": "checkKey",
+                "description": "Checks a password change key that was sent to the user email"
+            },
+            "post": {
+                "requestBody": {
+                    "description": "One of the request types: only login to get recovery key on email or key & a new password to change password",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "oneOf": [
+                                    {
+                                        "$ref": "#/components/schemas/NewPassword"
+                                    },
+                                    {
+                                        "$ref": "#/components/schemas/Login"
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Change password response (empty)"
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest"
+                    },
+                    "404": {
+                        "description": "Employee not found"
+                    },
+                    "429": {
+                        "description": "Too many request response"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "operationId": "changePassword",
+                "description": "Accepts a login and sends the key to change the password to the user email. \nOr it accepts the key and a new password and changes it."
+            }
         }
     },
     "components": {
@@ -2659,25 +2668,6 @@
                     "mobile": 79999999999,
                     "office": 123456
                 }
-            },
-            "ScanType": {
-                "description": "",
-                "enum": [
-                    "passport",
-                    "taxpayer",
-                    "insurance",
-                    "contract",
-                    "personal_data_processing",
-                    "military",
-                    "marriage",
-                    "baby_birth",
-                    "education",
-                    "briefing",
-                    "training",
-                    "work_permit",
-                    "other"
-                ],
-                "type": "string"
             },
             "Error": {
                 "required": [
@@ -2739,57 +2729,6 @@
                     "date_to": "2020-01-17",
                     "type": "temporary",
                     "number": "145678"
-                }
-            },
-            "Passport": {
-                "description": "",
-                "required": [],
-                "type": "object",
-                "properties": {
-                    "number": {
-                        "description": "",
-                        "maxLength": 50,
-                        "minLength": 2,
-                        "type": "string"
-                    },
-                    "issued_date": {
-                        "description": "",
-                        "maxLength": 8,
-                        "minLength": 8,
-                        "type": "string"
-                    },
-                    "issued_by": {
-                        "description": "",
-                        "maxLength": 150,
-                        "minLength": 2,
-                        "type": "string"
-                    },
-                    "type": {
-                        "description": "",
-                        "enum": [
-                            "internal",
-                            "external",
-                            "foreigners"
-                        ],
-                        "type": "string"
-                    },
-                    "id": {
-                        "description": "",
-                        "type": "integer"
-                    },
-                    "has_scan": {
-                        "description": "",
-                        "type": "boolean",
-                        "readOnly": true
-                    }
-                },
-                "example": {
-                    "id": 547,
-                    "has_scan": false,
-                    "number": "33592222",
-                    "issued_date": "2016-05-15",
-                    "issued_by": "Washington D.C. U.S.A.",
-                    "type": "foreigners"
                 }
             },
             "Visa": {
@@ -3194,64 +3133,6 @@
                     "has_scan": true
                 }
             },
-            "Training": {
-                "description": "",
-                "required": [],
-                "type": "object",
-                "properties": {
-                    "number": {
-                        "description": "",
-                        "maxLength": 50,
-                        "minLength": 2,
-                        "type": "string"
-                    },
-                    "issued_institution": {
-                        "description": "",
-                        "maxLength": 150,
-                        "minLength": 2,
-                        "type": "string"
-                    },
-                    "program": {
-                        "description": "",
-                        "maxLength": 150,
-                        "minLength": 2,
-                        "type": "string"
-                    },
-                    "cost": {
-                        "description": "cost per person",
-                        "type": "integer"
-                    },
-                    "date_to": {
-                        "format": "date",
-                        "description": "end date of training",
-                        "type": "string"
-                    },
-                    "date_from": {
-                        "format": "date",
-                        "description": "start date of training",
-                        "type": "string"
-                    },
-                    "id": {
-                        "description": "",
-                        "type": "integer"
-                    },
-                    "has_scan": {
-                        "description": "",
-                        "type": "boolean",
-                        "readOnly": true
-                    }
-                },
-                "example": {
-                    "number": "A15/456878-456",
-                    "issued_institution": "Yandex Practicum",
-                    "program": "Advanced Go developer",
-                    "cost": 120000,
-                    "date_to": "2023-01-10",
-                    "date_from": "2023-07-10",
-                    "id": 95,
-                    "has_scan": true
-                }
-            },
             "PositionTrack": {
                 "description": "",
                 "type": "array",
@@ -3288,7 +3169,61 @@
                     }
                 ]
             },
-            "FullUser": {
+            "Education": {
+                "description": "",
+                "required": [],
+                "type": "object",
+                "properties": {
+                    "number": {
+                        "description": "",
+                        "maxLength": 50,
+                        "minLength": 2,
+                        "type": "string"
+                    },
+                    "issued_institution": {
+                        "description": "",
+                        "maxLength": 150,
+                        "minLength": 2,
+                        "type": "string"
+                    },
+                    "date_to": {
+                        "format": "date",
+                        "description": "date of graduation",
+                        "type": "string"
+                    },
+                    "date_from": {
+                        "format": "date",
+                        "description": "date of commencement of studies",
+                        "type": "string"
+                    },
+                    "id": {
+                        "description": "",
+                        "type": "integer"
+                    },
+                    "has_scan": {
+                        "description": "",
+                        "type": "boolean",
+                        "readOnly": true
+                    },
+                    "program": {
+                        "description": "",
+                        "maxLength": 150,
+                        "minLength": 2,
+                        "type": "string"
+                    }
+                },
+                "example": {
+                    "id": 578,
+                    "has_scan": true,
+                    "number": "1030180354933",
+                    "date_to": "2015-01-01",
+                    "date_from": "2011-01-01",
+                    "issued_institution": "ФГБОУ ВО «Астраханский государственный университет им. В. Н. Татищева»",
+                    "program": "Связи с общественностью"
+                }
+            },
+            "PatchFullUser": {
+                "minProperties": 1,
                 "required": [],
                 "allOf": [
                     {
@@ -3301,6 +3236,10 @@
                                 "maxLength": 1,
                                 "minLength": 1,
                                 "type": "string"
+                            },
+                            "working_model": {
+                                "$ref": "#/components/schemas/WorkingModel",
+                                "description": ""
                             },
                             "date_of_birth": {
                                 "format": "date",
@@ -3344,6 +3283,175 @@
                                 "items": {
                                     "type": "string"
                                 }
+                            },
+                            "military": {
+                                "$ref": "#/components/schemas/Military",
+                                "description": ""
+                            },
+                            "taxpayer": {
+                                "$ref": "#/components/schemas/Taxpayer",
+                                "description": ""
+                            },
+                            "insurance": {
+                                "$ref": "#/components/schemas/Insurance"
+                            },
+                            "work_permit": {
+                                "$ref": "#/components/schemas/WorkPermit",
+                                "description": ""
+                            },
+                            "position_track": {
+                                "$ref": "#/components/schemas/PositionTrack",
+                                "description": ""
+                            }
+                        }
+                    }
+                ]
+            },
+            "ScanType": {
+                "description": "",
+                "default": "other",
+                "enum": [
+                    "passport",
+                    "taxpayer",
+                    "insurance",
+                    "contract",
+                    "personal_data_processing",
+                    "military",
+                    "marriage",
+                    "baby_birth",
+                    "education",
+                    "briefing",
+                    "training",
+                    "work_permit",
+                    "other"
+                ],
+                "type": "string"
+            },
+            "Passport": {
+                "description": "",
+                "required": [],
+                "type": "object",
+                "properties": {
+                    "number": {
+                        "description": "",
+                        "maxLength": 50,
+                        "minLength": 2,
+                        "type": "string"
+                    },
+                    "issued_date": {
+                        "description": "",
+                        "maxLength": 8,
+                        "minLength": 8,
+                        "type": "string"
+                    },
+                    "issued_by": {
+                        "description": "",
+                        "maxLength": 150,
+                        "minLength": 2,
+                        "type": "string"
+                    },
+                    "type": {
+                        "description": "",
+                        "default": "internal",
+                        "enum": [
+                            "internal",
+                            "external",
+                            "foreigners"
+                        ],
+                        "type": "string"
+                    },
+                    "id": {
+                        "description": "",
+                        "type": "integer"
+                    },
+                    "has_scan": {
+                        "description": "",
+                        "type": "boolean",
+                        "readOnly": true
+                    }
+                },
+                "example": {
+                    "id": 547,
+                    "has_scan": false,
+                    "number": "33592222",
+                    "issued_date": "2016-05-15",
+                    "issued_by": "Washington D.C. U.S.A.",
+                    "type": "foreigners"
+                }
+            },
+            "WorkingModel": {
+                "description": "",
+                "enum": [
+                    "remote",
+                    "hybrid",
+                    "in-office"
+                ],
+                "type": "string"
+            },
+            "FullUser": {
+                "required": [],
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/ShortUser"
+                    },
+                    {
+                        "properties": {
+                            "grade": {
+                                "description": "",
+                                "maxLength": 1,
+                                "minLength": 1,
+                                "type": "string"
+                            },
+                            "working_model": {
+                                "$ref": "#/components/schemas/WorkingModel",
+                                "description": ""
+                            },
+                            "date_of_birth": {
+                                "format": "date",
+                                "description": "",
+                                "type": "string"
+                            },
+                            "gender": {
+                                "enum": [
+                                    "male",
+                                    "female"
+                                ],
+                                "type": "string"
+                            },
+                            "place_of_birth": {
+                                "description": "",
+                                "maxLength": 150,
+                                "minLength": 2,
+                                "type": "string"
+                            },
+                            "registration_address": {
+                                "description": "",
+                                "maxLength": 150,
+                                "minLength": 2,
+                                "type": "string"
+                            },
+                            "residential_address": {
+                                "description": "",
+                                "maxLength": 150,
+                                "minLength": 2,
+                                "type": "string"
+                            },
+                            "nationality": {
+                                "description": "",
+                                "maxLength": 150,
+                                "minLength": 2,
+                                "type": "string"
+                            },
+                            "foreign_languages": {
+                                "description": "",
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "finance": {
+                                "$ref": "#/components/schemas/UserFinance",
+                                "readOnly": true
                             },
                             "position_track": {
                                 "description": "",
@@ -3423,7 +3531,25 @@
                     }
                 ],
                 "example": {
+                    "id": 1,
+                    "first_name": "Alexander",
+                    "last_name": "Pushkin",
+                    "middle_name": "Sergeyevich",
+                    "position": "Novelist",
+                    "department": "Collegium of Foreign Affairs",
+                    "email": "pushkin@dantes.net",
+                    "phone_numbers": [
+                        {
+                            "number": "799183712345",
+                            "type": "mobile"
+                        },
+                        {
+                            "number": "1837",
+                            "type": "office"
+                        }
+                    ],
                     "grade": "1",
+                    "working_model": "remote",
                     "date_of_birth": "2018-01-17",
                     "gender": "male",
                     "place_of_birth": "Москва",
@@ -3451,88 +3577,31 @@
                     }
                 }
             },
-            "PatchFullUser": {
-                "minProperties": 1,
-                "required": [],
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/ShortUser"
+            "UserFinance": {
+                "description": "",
+                "type": "object",
+                "properties": {
+                    "salary": {
+                        "format": "int64",
+                        "description": "gross salary per month, in their minor unit form",
+                        "type": "integer",
+                        "readOnly": true
                     },
-                    {
-                        "properties": {
-                            "grade": {
-                                "description": "",
-                                "maxLength": 1,
-                                "minLength": 1,
-                                "type": "string"
-                            },
-                            "date_of_birth": {
-                                "format": "date",
-                                "description": "",
-                                "type": "string"
-                            },
-                            "gender": {
-                                "enum": [
-                                    "male",
-                                    "female"
-                                ],
-                                "type": "string"
-                            },
-                            "place_of_birth": {
-                                "description": "",
-                                "maxLength": 150,
-                                "minLength": 2,
-                                "type": "string"
-                            },
-                            "registration_address": {
-                                "description": "",
-                                "maxLength": 150,
-                                "minLength": 2,
-                                "type": "string"
-                            },
-                            "residential_address": {
-                                "description": "",
-                                "maxLength": 150,
-                                "minLength": 2,
-                                "type": "string"
-                            },
-                            "nationality": {
-                                "description": "",
-                                "maxLength": 150,
-                                "minLength": 2,
-                                "type": "string"
-                            },
-                            "foreign_languages": {
-                                "description": "",
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "military": {
-                                "$ref": "#/components/schemas/Military",
-                                "description": ""
-                            },
-                            "taxpayer": {
-                                "$ref": "#/components/schemas/Taxpayer",
-                                "description": ""
-                            },
-                            "insurance": {
-                                "$ref": "#/components/schemas/Insurance"
-                            },
-                            "work_permit": {
-                                "$ref": "#/components/schemas/WorkPermit",
-                                "description": ""
-                            },
-                            "position_track": {
-                                "$ref": "#/components/schemas/PositionTrack",
-                                "description": ""
-                            }
-                        }
+                    "social_security_tax": {
+                        "format": "int64",
+                        "description": "tax paid to social services per month, in their minor unit form",
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "income_tax": {
+                        "format": "int64",
+                        "description": "tax paid to revenue service per month, in their minor unit form",
+                        "type": "integer",
+                        "readOnly": true
                     }
-                ]
+                }
             },
-            "Education": {
+            "Training": {
                 "description": "",
                 "required": [],
                 "type": "object",
@@ -3549,14 +3618,25 @@
                         "minLength": 2,
                         "type": "string"
                     },
+                    "program": {
+                        "description": "",
+                        "maxLength": 150,
+                        "minLength": 2,
+                        "type": "string"
+                    },
+                    "cost": {
+                        "format": "int64",
+                        "description": "cost per person, in their minor unit form",
+                        "type": "integer"
+                    },
                     "date_to": {
                         "format": "date",
-                        "description": "date of graduation",
+                        "description": "end date of training",
                         "type": "string"
                     },
                     "date_from": {
                         "format": "date",
-                        "description": "date of commencement of studies",
+                        "description": "start date of training",
                         "type": "string"
                     },
                     "id": {
@@ -3567,22 +3647,17 @@
                         "description": "",
                         "type": "boolean",
                         "readOnly": true
-                    },
-                    "program": {
-                        "description": "",
-                        "maxLength": 150,
-                        "minLength": 2,
-                        "type": "string"
                     }
                 },
                 "example": {
-                    "id": 578,
-                    "has_scan": true,
-                    "number": "1030180354933",
-                    "date_to": "2015-01-01",
-                    "date_from": "2011-01-01",
-                    "issued_institution": "ФГБОУ ВО «Астраханский государственный университет им. В. Н. Татищева»",
-                    "program": "Связи с общественностью"
+                    "number": "A15/456878-456",
+                    "issued_institution": "Yandex Practicum",
+                    "program": "Advanced Go developer",
+                    "cost": 120000,
+                    "date_to": "2023-01-10",
+                    "date_from": "2023-07-10",
+                    "id": 95,
+                    "has_scan": true
                 }
             }
         },

--- a/api/api.json
+++ b/api/api.json
@@ -2,7 +2,7 @@
     "openapi": "3.0.2",
     "info": {
         "title": "Employee's cabinet",
-        "version": "0.8.0",
+        "version": "0.9.0",
         "description": "",
         "contact": {
             "name": "Yandex Practicum Students Team"
@@ -1131,236 +1131,6 @@
                 }
             ]
         },
-        "/users": {
-            "get": {
-                "parameters": [
-                    {
-                        "examples": {
-                            "Limit example": {
-                                "value": "50"
-                            }
-                        },
-                        "name": "limit",
-                        "description": "maximum number of results to return",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "query",
-                        "required": false
-                    },
-                    {
-                        "examples": {
-                            "Query": {
-                                "value": "\"Иванов\""
-                            }
-                        },
-                        "name": "query",
-                        "description": "query to find by",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "in": "query"
-                    },
-                    {
-                        "examples": {
-                            "Page example": {
-                                "value": "2"
-                            }
-                        },
-                        "name": "page",
-                        "description": "page number with results to return",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "query"
-                    },
-                    {
-                        "examples": {
-                            "SortByExample": {
-                                "value": "\"alphabet\""
-                            }
-                        },
-                        "name": "sort_by",
-                        "description": "type of sort result by",
-                        "schema": {
-                            "enum": [
-                                "alphabet",
-                                "department"
-                            ],
-                            "type": "string"
-                        },
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "allOf": [
-                                            {
-                                                "$ref": "#/components/schemas/ShortUser"
-                                            },
-                                            {
-                                                "required": [
-                                                    "id",
-                                                    "first_name",
-                                                    "last_name"
-                                                ],
-                                                "type": "object"
-                                            }
-                                        ]
-                                    }
-                                },
-                                "examples": {
-                                    "List employees example": {
-                                        "value": [
-                                            {
-                                                "first_name": "Alexander",
-                                                "last_name": "Pushkin",
-                                                "middle_name": "Sergeyevich",
-                                                "position": "Novelist",
-                                                "department": "Collegium of Foreign Affairs",
-                                                "email": "pushkin@dantes.net",
-                                                "phone_numbers": [
-                                                    {
-                                                        "number": "799183712345",
-                                                        "type": "mobile"
-                                                    },
-                                                    {
-                                                        "number": "1837",
-                                                        "type": "office"
-                                                    }
-                                                ]
-                                            },
-                                            {
-                                                "first_name": "Nikolai",
-                                                "last_name": "Gogol",
-                                                "middle_name": "Vasilievich",
-                                                "position": "Playwright",
-                                                "department": "Third Section of His Imperial Majesty's Own Chancellery",
-                                                "email": "gogol@fire.net",
-                                                "phone_numbers": [
-                                                    {
-                                                        "number": "799185212345",
-                                                        "type": "mobile"
-                                                    },
-                                                    {
-                                                        "number": "1821",
-                                                        "type": "office"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            }
-                        },
-                        "description": "Employees list response"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/UnauthorizedError"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": []
-                    }
-                ],
-                "operationId": "listUsers",
-                "description": "Returns list of company employees sorted alphabetically (default) or by department"
-            },
-            "post": {
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/FullUser"
-                                    },
-                                    {
-                                        "required": [
-                                            "first_name",
-                                            "last_name",
-                                            "date_of_birth"
-                                        ],
-                                        "type": "object"
-                                    }
-                                ]
-                            },
-                            "examples": {
-                                "Post employee example": {
-                                    "value": {
-                                        "first_name": "Alexander",
-                                        "last_name": "Pushkin",
-                                        "middle_name": "Sergeyevich",
-                                        "position": "Novelist",
-                                        "department": "Collegium of Foreign Affairs",
-                                        "email": "pushkin@dantes.net",
-                                        "phone_numbers": [
-                                            {
-                                                "number": "799183712345",
-                                                "type": "mobile"
-                                            },
-                                            {
-                                                "number": "1837",
-                                                "type": "office"
-                                            }
-                                        ],
-                                        "foreign_languages": [
-                                            "english",
-                                            "german"
-                                        ],
-                                        "military": {
-                                            "rank": "Старший лейтенант",
-                                            "speciality": "101182",
-                                            "category": "А2",
-                                            "comissariat": "Военный комиссариат Петроградского района г. Санкт-Петербурга"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "201": {
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "format": "uri",
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "description": "Employee created response, \nLocation header returns a new employee URL"
-                    },
-                    "400": {
-                        "$ref": "#/components/responses/BadRequest"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/UnauthorizedError"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": []
-                    }
-                ],
-                "operationId": "addUser",
-                "description": "Creates a new employe in the company"
-            }
-        },
         "/login": {
             "post": {
                 "requestBody": {
@@ -2078,6 +1848,237 @@
                     "required": true
                 }
             ]
+        },
+        "/users": {
+            "get": {
+                "parameters": [
+                    {
+                        "examples": {
+                            "Limit example": {
+                                "value": "50"
+                            }
+                        },
+                        "name": "limit",
+                        "description": "maximum number of results to return",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "in": "query",
+                        "required": false
+                    },
+                    {
+                        "examples": {
+                            "Query": {
+                                "value": "\"Иванов\""
+                            }
+                        },
+                        "name": "query",
+                        "description": "query to find by",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "in": "query"
+                    },
+                    {
+                        "examples": {
+                            "Page example": {
+                                "value": "2"
+                            }
+                        },
+                        "name": "page",
+                        "description": "page number with results to return",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "in": "query"
+                    },
+                    {
+                        "examples": {
+                            "SortByExample": {
+                                "value": "\"alphabet\""
+                            }
+                        },
+                        "name": "sort_by",
+                        "description": "type of sort result by",
+                        "schema": {
+                            "enum": [
+                                "alphabet",
+                                "department"
+                            ],
+                            "type": "string"
+                        },
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "allOf": [
+                                            {
+                                                "$ref": "#/components/schemas/ShortUser"
+                                            },
+                                            {
+                                                "required": [
+                                                    "id",
+                                                    "first_name",
+                                                    "last_name"
+                                                ],
+                                                "type": "object"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "examples": {
+                                    "List employees example": {
+                                        "value": [
+                                            {
+                                                "first_name": "Alexander",
+                                                "last_name": "Pushkin",
+                                                "middle_name": "Sergeyevich",
+                                                "position": "Novelist",
+                                                "department": "Collegium of Foreign Affairs",
+                                                "email": "pushkin@dantes.net",
+                                                "phone_numbers": [
+                                                    {
+                                                        "number": "799183712345",
+                                                        "type": "mobile"
+                                                    },
+                                                    {
+                                                        "number": "1837",
+                                                        "type": "office"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "first_name": "Nikolai",
+                                                "last_name": "Gogol",
+                                                "middle_name": "Vasilievich",
+                                                "position": "Playwright",
+                                                "department": "Third Section of His Imperial Majesty's Own Chancellery",
+                                                "email": "gogol@fire.net",
+                                                "phone_numbers": [
+                                                    {
+                                                        "number": "799185212345",
+                                                        "type": "mobile"
+                                                    },
+                                                    {
+                                                        "number": "1821",
+                                                        "type": "office"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                        "description": "Employees list response"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "listUsers",
+                "description": "Returns list of company employees sorted alphabetically (default) or by department"
+            },
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/FullUser"
+                                    },
+                                    {
+                                        "required": [
+                                            "first_name",
+                                            "last_name",
+                                            "date_of_birth"
+                                        ],
+                                        "type": "object"
+                                    }
+                                ]
+                            },
+                            "examples": {
+                                "Post employee example": {
+                                    "value": {
+                                        "first_name": "Alexander",
+                                        "last_name": "Pushkin",
+                                        "middle_name": "Sergeyevich",
+                                        "gender": "male",
+                                        "position": "Novelist",
+                                        "department": "Collegium of Foreign Affairs",
+                                        "email": "pushkin@dantes.net",
+                                        "phone_numbers": [
+                                            {
+                                                "number": "799183712345",
+                                                "type": "mobile"
+                                            },
+                                            {
+                                                "number": "1837",
+                                                "type": "office"
+                                            }
+                                        ],
+                                        "foreign_languages": [
+                                            "english",
+                                            "german"
+                                        ],
+                                        "military": {
+                                            "rank": "Старший лейтенант",
+                                            "speciality": "101182",
+                                            "category": "А2",
+                                            "comissariat": "Военный комиссариат Петроградского района г. Санкт-Петербурга"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "headers": {
+                            "Location": {
+                                "schema": {
+                                    "format": "uri",
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Employee created response, \nLocation header returns a new employee URL"
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "500": {
+                        "$ref": "#/components/responses/InternalServerError"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ],
+                "operationId": "addUser",
+                "description": "Creates a new employe in the company"
+            }
         }
     },
     "components": {
@@ -2568,6 +2569,52 @@
                     "has_scan": true
                 }
             },
+            "Insurance": {
+                "description": "",
+                "type": "object",
+                "properties": {
+                    "number": {
+                        "description": "",
+                        "maxLength": 11,
+                        "minLength": 11,
+                        "type": "string"
+                    },
+                    "has_scan": {
+                        "description": "",
+                        "type": "boolean",
+                        "readOnly": true
+                    }
+                },
+                "example": {
+                    "number": "08336732477",
+                    "has_scan": true
+                }
+            },
+            "Department": {
+                "description": "",
+                "required": [],
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "description": "",
+                        "maxLength": 150,
+                        "minLength": 2,
+                        "type": "string"
+                    },
+                    "users_number": {
+                        "description": "current number of working employees",
+                        "type": "integer"
+                    },
+                    "id": {
+                        "description": "",
+                        "type": "integer"
+                    },
+                    "recruited_users_number": {
+                        "description": "number of recruited employees",
+                        "type": "integer"
+                    }
+                }
+            },
             "FullUser": {
                 "required": [],
                 "allOf": [
@@ -2585,6 +2632,13 @@
                             "date_of_birth": {
                                 "format": "date",
                                 "description": "",
+                                "type": "string"
+                            },
+                            "gender": {
+                                "enum": [
+                                    "male",
+                                    "female"
+                                ],
                                 "type": "string"
                             },
                             "place_of_birth": {
@@ -2680,6 +2734,7 @@
                 "example": {
                     "grade": "1",
                     "date_of_birth": "2018-01-17",
+                    "gender": "male",
                     "place_of_birth": "Москва",
                     "registration_address": "Санкт-Петербург, наб. реки Мойки, 12",
                     "residential_address": "Санкт-Петербург, наб. реки Мойки, 12",
@@ -2705,27 +2760,6 @@
                     }
                 }
             },
-            "Insurance": {
-                "description": "",
-                "type": "object",
-                "properties": {
-                    "number": {
-                        "description": "",
-                        "maxLength": 11,
-                        "minLength": 11,
-                        "type": "string"
-                    },
-                    "has_scan": {
-                        "description": "",
-                        "type": "boolean",
-                        "readOnly": true
-                    }
-                },
-                "example": {
-                    "number": "08336732477",
-                    "has_scan": true
-                }
-            },
             "PatchFullUser": {
                 "minProperties": 1,
                 "required": [],
@@ -2744,6 +2778,13 @@
                             "date_of_birth": {
                                 "format": "date",
                                 "description": "",
+                                "type": "string"
+                            },
+                            "gender": {
+                                "enum": [
+                                    "male",
+                                    "female"
+                                ],
                                 "type": "string"
                             },
                             "place_of_birth": {
@@ -2795,31 +2836,6 @@
                         }
                     }
                 ]
-            },
-            "Department": {
-                "description": "",
-                "required": [],
-                "type": "object",
-                "properties": {
-                    "name": {
-                        "description": "",
-                        "maxLength": 150,
-                        "minLength": 2,
-                        "type": "string"
-                    },
-                    "users_number": {
-                        "description": "current number of working employees",
-                        "type": "integer"
-                    },
-                    "id": {
-                        "description": "",
-                        "type": "integer"
-                    },
-                    "recruited_users_number": {
-                        "description": "number of recruited employees",
-                        "type": "integer"
-                    }
-                }
             }
         },
         "responses": {

--- a/api/api.json
+++ b/api/api.json
@@ -2,7 +2,7 @@
     "openapi": "3.0.2",
     "info": {
         "title": "Employee's cabinet",
-        "version": "0.14.0",
+        "version": "0.14.1",
         "description": "",
         "contact": {
             "name": "Yandex Practicum Students Team"
@@ -56,8 +56,14 @@
                     "401": {
                         "$ref": "#/components/responses/UnauthorizedError"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -102,8 +108,14 @@
                     "401": {
                         "$ref": "#/components/responses/UnauthorizedError"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -166,8 +178,14 @@
                         },
                         "description": "Add contract conflict response: the contract already exists"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -223,8 +241,14 @@
                     "404": {
                         "description": "Employee/contract not found response"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -245,8 +269,14 @@
                     "401": {
                         "$ref": "#/components/responses/UnauthorizedError"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -287,8 +317,14 @@
                     "401": {
                         "$ref": "#/components/responses/UnauthorizedError"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -354,8 +390,14 @@
                     "404": {
                         "description": "Employee/passport/visa not found response"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -376,8 +418,14 @@
                     "401": {
                         "$ref": "#/components/responses/UnauthorizedError"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -418,8 +466,14 @@
                     "401": {
                         "$ref": "#/components/responses/UnauthorizedError"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -496,8 +550,14 @@
                     "404": {
                         "description": "Employee/passport not found response"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -563,8 +623,14 @@
                     "401": {
                         "$ref": "#/components/responses/UnauthorizedError"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -700,8 +766,14 @@
                     "404": {
                         "description": "Employee/passport not found response"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -722,8 +794,14 @@
                     "401": {
                         "$ref": "#/components/responses/UnauthorizedError"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -764,8 +842,14 @@
                     "401": {
                         "$ref": "#/components/responses/UnauthorizedError"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -827,8 +911,14 @@
                     "404": {
                         "description": "Employee/vacation not found response"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -849,8 +939,14 @@
                     "401": {
                         "$ref": "#/components/responses/UnauthorizedError"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -891,8 +987,14 @@
                     "401": {
                         "$ref": "#/components/responses/UnauthorizedError"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -954,8 +1056,14 @@
                     "401": {
                         "$ref": "#/components/responses/UnauthorizedError"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -1010,8 +1118,14 @@
                     "409": {
                         "description": "Add vacation conflict response: the dates indicated conflict with the available ones"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -1086,8 +1200,14 @@
                     "404": {
                         "description": "Employee not found response"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -1148,8 +1268,14 @@
                     "401": {
                         "$ref": "#/components/responses/UnauthorizedError"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -1200,8 +1326,14 @@
                     "401": {
                         "$ref": "#/components/responses/UnauthorizedError"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -1222,8 +1354,14 @@
                     "401": {
                         "$ref": "#/components/responses/UnauthorizedError"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -1303,8 +1441,14 @@
                     "401": {
                         "$ref": "#/components/responses/UnauthorizedError"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -1373,8 +1517,14 @@
                     "404": {
                         "description": "Employee not found response"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -1441,8 +1591,14 @@
                     "409": {
                         "description": "Add passport conflict response: the passport already exists"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -1487,8 +1643,14 @@
                     "401": {
                         "$ref": "#/components/responses/UnauthorizedError"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -1550,8 +1712,14 @@
                         },
                         "description": "Add education conflict response: the education already exists"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -1606,8 +1774,14 @@
                     "404": {
                         "description": "Employee/education not found response"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -1628,8 +1802,14 @@
                     "401": {
                         "$ref": "#/components/responses/UnauthorizedError"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -1670,8 +1850,14 @@
                     "401": {
                         "$ref": "#/components/responses/UnauthorizedError"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -1735,8 +1921,14 @@
                     "401": {
                         "$ref": "#/components/responses/UnauthorizedError"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -1799,8 +1991,14 @@
                         },
                         "description": "Add training conflict response: the training already exists"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -1856,8 +2054,14 @@
                     "404": {
                         "description": "Employee/training not found response"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -1878,8 +2082,14 @@
                     "401": {
                         "$ref": "#/components/responses/UnauthorizedError"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -1920,8 +2130,14 @@
                     "401": {
                         "$ref": "#/components/responses/UnauthorizedError"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -1953,243 +2169,6 @@
                 }
             ]
         },
-        "/users": {
-            "get": {
-                "parameters": [
-                    {
-                        "examples": {
-                            "Limit example": {
-                                "value": "50"
-                            }
-                        },
-                        "name": "limit",
-                        "description": "maximum number of results to return",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "query",
-                        "required": false
-                    },
-                    {
-                        "examples": {
-                            "Query": {
-                                "value": "\"Иванов\""
-                            }
-                        },
-                        "name": "query",
-                        "description": "query to find by",
-                        "schema": {
-                            "type": "string"
-                        },
-                        "in": "query"
-                    },
-                    {
-                        "examples": {
-                            "Page example": {
-                                "value": "2"
-                            }
-                        },
-                        "name": "page",
-                        "description": "page number with results to return",
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "in": "query"
-                    },
-                    {
-                        "examples": {
-                            "SortByExample": {
-                                "value": "\"alphabet\""
-                            }
-                        },
-                        "name": "sort_by",
-                        "description": "type of sort result by",
-                        "schema": {
-                            "default": "alphabet",
-                            "enum": [
-                                "alphabet",
-                                "department"
-                            ],
-                            "type": "string"
-                        },
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "allOf": [
-                                            {
-                                                "$ref": "#/components/schemas/ShortUser"
-                                            },
-                                            {
-                                                "required": [
-                                                    "id",
-                                                    "first_name",
-                                                    "last_name"
-                                                ],
-                                                "type": "object"
-                                            }
-                                        ]
-                                    }
-                                },
-                                "examples": {
-                                    "List employees example": {
-                                        "value": [
-                                            {
-                                                "first_name": "Alexander",
-                                                "last_name": "Pushkin",
-                                                "middle_name": "Sergeyevich",
-                                                "position": "Novelist",
-                                                "department": "Collegium of Foreign Affairs",
-                                                "email": "pushkin@dantes.net",
-                                                "phone_numbers": [
-                                                    {
-                                                        "number": "799183712345",
-                                                        "type": "mobile"
-                                                    },
-                                                    {
-                                                        "number": "1837",
-                                                        "type": "office"
-                                                    }
-                                                ]
-                                            },
-                                            {
-                                                "first_name": "Nikolai",
-                                                "last_name": "Gogol",
-                                                "middle_name": "Vasilievich",
-                                                "position": "Playwright",
-                                                "department": "Third Section of His Imperial Majesty's Own Chancellery",
-                                                "email": "gogol@fire.net",
-                                                "phone_numbers": [
-                                                    {
-                                                        "number": "799185212345",
-                                                        "type": "mobile"
-                                                    },
-                                                    {
-                                                        "number": "1821",
-                                                        "type": "office"
-                                                    }
-                                                ]
-                                            }
-                                        ]
-                                    }
-                                }
-                            }
-                        },
-                        "description": "Employees list response"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/UnauthorizedError"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": [
-                            "user:read"
-                        ]
-                    }
-                ],
-                "operationId": "listUsers",
-                "description": "Returns list of company employees sorted alphabetically (default) or by department"
-            },
-            "post": {
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/FullUser"
-                                    },
-                                    {
-                                        "required": [
-                                            "first_name",
-                                            "last_name",
-                                            "date_of_birth",
-                                            "gender"
-                                        ],
-                                        "type": "object"
-                                    }
-                                ]
-                            },
-                            "examples": {
-                                "Post employee example": {
-                                    "value": {
-                                        "first_name": "Alexander",
-                                        "last_name": "Pushkin",
-                                        "middle_name": "Sergeyevich",
-                                        "gender": "male",
-                                        "position": "Novelist",
-                                        "department": "Collegium of Foreign Affairs",
-                                        "email": "pushkin@dantes.net",
-                                        "phone_numbers": [
-                                            {
-                                                "number": "799183712345",
-                                                "type": "mobile"
-                                            },
-                                            {
-                                                "number": "1837",
-                                                "type": "office"
-                                            }
-                                        ],
-                                        "foreign_languages": [
-                                            "english",
-                                            "german"
-                                        ],
-                                        "military": {
-                                            "rank": "Старший лейтенант",
-                                            "speciality": "101182",
-                                            "category": "А2",
-                                            "comissariat": "Военный комиссариат Петроградского района г. Санкт-Петербурга"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "201": {
-                        "headers": {
-                            "Location": {
-                                "schema": {
-                                    "format": "uri",
-                                    "type": "string"
-                                }
-                            }
-                        },
-                        "description": "Employee created response, \nLocation header returns a new employee URL"
-                    },
-                    "400": {
-                        "$ref": "#/components/responses/BadRequest"
-                    },
-                    "401": {
-                        "$ref": "#/components/responses/UnauthorizedError"
-                    },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
-                    }
-                },
-                "security": [
-                    {
-                        "bearerAuth": [
-                            "user:create"
-                        ]
-                    }
-                ],
-                "operationId": "addUser",
-                "description": "Creates a new employe in the company"
-            }
-        },
         "/login/change-password": {
             "get": {
                 "parameters": [
@@ -2219,8 +2198,14 @@
                     "429": {
                         "description": "Too many request response"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
                     }
                 },
                 "operationId": "checkKey",
@@ -2258,8 +2243,14 @@
                     "429": {
                         "description": "Too many request response"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
                     }
                 },
                 "operationId": "changePassword",
@@ -2319,8 +2310,14 @@
                     "401": {
                         "$ref": "#/components/responses/UnauthorizedError"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
                     }
                 },
                 "operationId": "login",
@@ -2684,8 +2681,14 @@
                     "404": {
                         "description": "Employee not found response"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -2730,8 +2733,14 @@
                     "404": {
                         "description": "Employee not found"
                     },
-                    "500": {
-                        "$ref": "#/components/responses/InternalServerError"
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
                     }
                 },
                 "security": [
@@ -2755,6 +2764,265 @@
                     "required": true
                 }
             ]
+        },
+        "/users": {
+            "get": {
+                "parameters": [
+                    {
+                        "examples": {
+                            "Limit example": {
+                                "value": "50"
+                            }
+                        },
+                        "name": "limit",
+                        "description": "maximum number of results to return",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "in": "query",
+                        "required": false
+                    },
+                    {
+                        "examples": {
+                            "Query": {
+                                "value": "\"Иванов\""
+                            }
+                        },
+                        "name": "query",
+                        "description": "query to find by",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "in": "query"
+                    },
+                    {
+                        "examples": {
+                            "Page example": {
+                                "value": "2"
+                            }
+                        },
+                        "name": "page",
+                        "description": "page number with results to return",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "in": "query"
+                    },
+                    {
+                        "examples": {
+                            "SortByExample": {
+                                "value": "\"alphabet\""
+                            }
+                        },
+                        "name": "sort_by",
+                        "description": "type of sort result by",
+                        "schema": {
+                            "default": "alphabet",
+                            "enum": [
+                                "alphabet",
+                                "department"
+                            ],
+                            "type": "string"
+                        },
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "allOf": [
+                                            {
+                                                "$ref": "#/components/schemas/ShortUser"
+                                            },
+                                            {
+                                                "required": [
+                                                    "id",
+                                                    "first_name",
+                                                    "last_name"
+                                                ],
+                                                "type": "object"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "examples": {
+                                    "List employees example": {
+                                        "value": [
+                                            {
+                                                "first_name": "Alexander",
+                                                "last_name": "Pushkin",
+                                                "middle_name": "Sergeyevich",
+                                                "position": "Novelist",
+                                                "department": "Collegium of Foreign Affairs",
+                                                "email": "pushkin@dantes.net",
+                                                "phone_numbers": [
+                                                    {
+                                                        "number": "799183712345",
+                                                        "type": "mobile"
+                                                    },
+                                                    {
+                                                        "number": "1837",
+                                                        "type": "office"
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "first_name": "Nikolai",
+                                                "last_name": "Gogol",
+                                                "middle_name": "Vasilievich",
+                                                "position": "Playwright",
+                                                "department": "Third Section of His Imperial Majesty's Own Chancellery",
+                                                "email": "gogol@fire.net",
+                                                "phone_numbers": [
+                                                    {
+                                                        "number": "799185212345",
+                                                        "type": "mobile"
+                                                    },
+                                                    {
+                                                        "number": "1821",
+                                                        "type": "office"
+                                                    }
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                        "description": "Employees list response"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "user:read"
+                        ]
+                    }
+                ],
+                "operationId": "listUsers",
+                "description": "Returns list of company employees sorted alphabetically (default) or by department"
+            },
+            "post": {
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/FullUser"
+                                    },
+                                    {
+                                        "required": [
+                                            "first_name",
+                                            "last_name",
+                                            "date_of_birth",
+                                            "gender"
+                                        ],
+                                        "type": "object"
+                                    }
+                                ]
+                            },
+                            "examples": {
+                                "Post employee example": {
+                                    "value": {
+                                        "first_name": "Alexander",
+                                        "last_name": "Pushkin",
+                                        "middle_name": "Sergeyevich",
+                                        "gender": "male",
+                                        "position": "Novelist",
+                                        "department": "Collegium of Foreign Affairs",
+                                        "email": "pushkin@dantes.net",
+                                        "phone_numbers": [
+                                            {
+                                                "number": "799183712345",
+                                                "type": "mobile"
+                                            },
+                                            {
+                                                "number": "1837",
+                                                "type": "office"
+                                            }
+                                        ],
+                                        "foreign_languages": [
+                                            "english",
+                                            "german"
+                                        ],
+                                        "military": {
+                                            "rank": "Старший лейтенант",
+                                            "speciality": "101182",
+                                            "category": "А2",
+                                            "comissariat": "Военный комиссариат Петроградского района г. Санкт-Петербурга"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "headers": {
+                            "Location": {
+                                "schema": {
+                                    "format": "uri",
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "Employee created response, \nLocation header returns a new employee URL"
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "409": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        },
+                        "description": "Add user conflict response: the user already exists"
+                    },
+                    "default": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": [
+                            "user:create"
+                        ]
+                    }
+                ],
+                "operationId": "addUser",
+                "description": "Creates a new employe in the company"
+            }
         }
     },
     "components": {
@@ -3797,16 +4065,6 @@
                     }
                 },
                 "description": "Access token is missing or invalid"
-            },
-            "InternalServerError": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "$ref": "#/components/schemas/Error"
-                        }
-                    }
-                },
-                "description": "Internal Server Error"
             },
             "BadRequest": {
                 "content": {

--- a/api/api.json
+++ b/api/api.json
@@ -2,7 +2,7 @@
     "openapi": "3.0.2",
     "info": {
         "title": "Employee's cabinet",
-        "version": "0.6.0",
+        "version": "0.7.0",
         "description": "",
         "contact": {
             "name": "Yandex Practicum Students Team"
@@ -2140,27 +2140,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "required": [
-                                    "login",
-                                    "password"
-                                ],
-                                "type": "object",
-                                "properties": {
-                                    "login": {
-                                        "description": "employee login (email)",
-                                        "maxLength": 15,
-                                        "minLength": 5,
-                                        "type": "string",
-                                        "example": "anna@gazneft.ru"
-                                    },
-                                    "password": {
-                                        "format": "password",
-                                        "description": "employee password",
-                                        "maxLength": 15,
-                                        "minLength": 8,
-                                        "type": "string"
-                                    }
-                                }
+                                "$ref": "#/components/schemas/Auth"
                             }
                         }
                     },
@@ -2239,10 +2219,10 @@
                             "schema": {
                                 "oneOf": [
                                     {
-                                        "$ref": "#/components/schemas/ChangePasswordPassword"
+                                        "$ref": "#/components/schemas/NewPassword"
                                     },
                                     {
-                                        "$ref": "#/components/schemas/ChangePasswordLogin"
+                                        "$ref": "#/components/schemas/Login"
                                     }
                                 ]
                             }
@@ -2423,34 +2403,6 @@
                 "example": {
                     "number": "08336732477",
                     "has_scan": true
-                }
-            },
-            "ChangePasswordPassword": {
-                "description": "",
-                "required": [
-                    "key",
-                    "password"
-                ],
-                "type": "object",
-                "properties": {
-                    "key": {
-                        "format": "byte",
-                        "description": "a special key sent to the employee’s email",
-                        "maxLength": 64,
-                        "minLength": 64,
-                        "type": "string"
-                    },
-                    "password": {
-                        "format": "password",
-                        "description": "a new employee password",
-                        "maxLength": 15,
-                        "minLength": 8,
-                        "type": "string"
-                    }
-                },
-                "example": {
-                    "key": "0LzQsNC80LAg0LzRi9C70LAg0YDQsNC80YM=",
-                    "password": "pa$$word"
                 }
             },
             "WorkPermit": {
@@ -2876,14 +2828,14 @@
                     }
                 }
             },
-            "ChangePasswordLogin": {
+            "Login": {
                 "description": "",
                 "required": [
-                    "email"
+                    "login"
                 ],
                 "type": "object",
                 "properties": {
-                    "email": {
+                    "login": {
                         "format": "email",
                         "description": "employee login (email)",
                         "maxLength": 50,
@@ -2893,6 +2845,60 @@
                 },
                 "example": {
                     "login": "vasyapp&gazneft.ru"
+                }
+            },
+            "NewPassword": {
+                "description": "",
+                "required": [
+                    "key",
+                    "password"
+                ],
+                "type": "object",
+                "properties": {
+                    "key": {
+                        "format": "byte",
+                        "description": "a special key sent to the employee’s email",
+                        "maxLength": 64,
+                        "minLength": 64,
+                        "type": "string"
+                    },
+                    "password": {
+                        "format": "password",
+                        "description": "a new employee password",
+                        "maxLength": 15,
+                        "minLength": 8,
+                        "type": "string"
+                    }
+                },
+                "example": {
+                    "key": "0LzQsNC80LAg0LzRi9C70LAg0YDQsNC80YM=",
+                    "password": "pa$$word"
+                }
+            },
+            "Auth": {
+                "description": "",
+                "required": [
+                    "login",
+                    "password"
+                ],
+                "type": "object",
+                "properties": {
+                    "login": {
+                        "format": "email",
+                        "description": "employee login (email)",
+                        "maxLength": 15,
+                        "minLength": 5,
+                        "type": "string",
+                        "example": "anna@gazneft.ru"
+                    },
+                    "password": {
+                        "format": "password",
+                        "description": "employee password",
+                        "maxLength": 15,
+                        "minLength": 8,
+                        "type": "string",
+                        "example": "pa$$word"
+                    }
                 }
             }
         },

--- a/api/api.json
+++ b/api/api.json
@@ -2,7 +2,7 @@
     "openapi": "3.0.2",
     "info": {
         "title": "Employee's cabinet",
-        "version": "0.7.0",
+        "version": "0.7.1",
         "description": "",
         "contact": {
             "name": "Yandex Practicum Students Team"
@@ -2169,6 +2169,7 @@
                 "properties": {
                     "rank": {
                         "description": "",
+                        "maxLength": 150,
                         "type": "string"
                     },
                     "speciality": {
@@ -2185,6 +2186,7 @@
                     },
                     "comissariat": {
                         "description": "",
+                        "maxLength": 150,
                         "type": "string"
                     },
                     "has_scan": {
@@ -2653,6 +2655,7 @@
                     },
                     "description": {
                         "description": "",
+                        "maxLength": 150,
                         "type": "string"
                     },
                     "document_id": {
@@ -2729,7 +2732,7 @@
                     "login": {
                         "format": "email",
                         "description": "employee login (email)",
-                        "maxLength": 15,
+                        "maxLength": 50,
                         "minLength": 5,
                         "type": "string",
                         "example": "anna@gazneft.ru"

--- a/api/api.json
+++ b/api/api.json
@@ -2,7 +2,7 @@
     "openapi": "3.0.2",
     "info": {
         "title": "Employee's cabinet",
-        "version": "0.7.2",
+        "version": "0.7.3",
         "description": "",
         "contact": {
             "name": "Yandex Practicum Students Team"
@@ -1185,7 +1185,7 @@
                         "bearerAuth": []
                     }
                 ],
-                "operationId": "postVacation",
+                "operationId": "addVacation",
                 "description": "Creates a new employee's vacation"
             },
             "parameters": [


### PR DESCRIPTION
Added types:
- education
- training
- working model
- user finance

Added properties to user scheme:
- educations
- trainings
- track of positions
- working model
- finance
- gender 

Added paths:
- /users/{user_id}/educations (GET, POST)
- /users/{user_id}/educations/{education_id} (GET, DELETE, PATCH)
- /users/{user_id}/trainings (GET, POST)
- /users/{user_id}/trainings/{training_id} (GET, DELETE, PATCH)

Simplified schemas.

Renamed (!): 
- operation id: postVacation -> addVacation
- token - > access_token
- auth shemas

Version up to 0.14.0