### PR TITLE
fix: superfluous write header,  generate key to recover password

### DIFF
--- a/internal/delivery/http/internal/api/types_validate.go
+++ b/internal/delivery/http/internal/api/types_validate.go
@@ -27,7 +27,6 @@ func (b ChangePasswordJSONRequestBody) Validate(ctx context.Context, validator *
 		vld.StringProperty("key", b.Key,
 			it.IsNotBlank(),
 			it.HasExactLength(36)),
-		vld.StringProperty("key", b.Key, it.Matches(rxBase64)),
 		vld.StringProperty("password", b.Password,
 			it.IsNotBlank(),
 			it.HasLengthBetween(8, 15)),
@@ -589,7 +588,6 @@ func (cp CheckKeyParams) Validate(ctx context.Context, validator *vld.Validator)
 		vld.StringProperty("key", cp.Key,
 			it.IsNotBlank(),
 			it.HasExactLength(36)),
-		vld.StringProperty("key", string(cp.Key), it.Matches(rxBase64)),
 	)
 }
 

--- a/internal/delivery/http/internal/api/validate.go
+++ b/internal/delivery/http/internal/api/validate.go
@@ -2,15 +2,10 @@
 package api
 
 import (
-	"regexp"
 	"strings"
 
 	vld "github.com/muonsoft/validation"
 )
-
-const base64 string = "^(?:[A-Za-z0-9+\\/]{4})*(?:[A-Za-z0-9+\\/]{2}==|[A-Za-z0-9+\\/]{3}=|[A-Za-z0-9+\\/]{4})$"
-
-var rxBase64 = regexp.MustCompile(base64)
 
 var (
 	ErrInvalidOnlyNumbersFormat = vld.NewError(

--- a/internal/delivery/http/internal/errors/errors.go
+++ b/internal/delivery/http/internal/errors/errors.go
@@ -34,18 +34,17 @@ func LogError(r *http.Request, err error, withStack bool) {
 // ResponseError converts error message to api.Error and writes this one in JSON format to response writer.
 func ResponseError(w http.ResponseWriter, r *http.Request, status int, errMessage string) {
 	message := strings.ToUpper(errMessage[:1]) + errMessage[1:]
-	w.WriteHeader(status)
 	if status == http.StatusNotModified {
 		// RFC 2616:
 		// The 304 response MUST NOT contain a message-body,
 		// and thus is always terminated by the first empty line after the header fields.
+		w.WriteHeader(status)
 		return
 	}
 	if err := response.JSON(w,
 		status,
 		api.Error{Message: message}); err != nil {
 		LogError(r, err, false)
-		w.WriteHeader(http.StatusInternalServerError)
 	}
 }
 


### PR DESCRIPTION
баг при ответе клиенту ошибкой: отправка заголовков после записи тела, 
баг в генерации query parameter key при сбросе пароля: "+" преобразуется при ответе нам в " "